### PR TITLE
feat: 퀴즈 진입 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.paykidscompose.app"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/QuizType.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/QuizType.kt
@@ -1,0 +1,5 @@
+package com.paykidscompose.presentation.model
+
+enum class QuizType {
+    IMAGE, MULTIPLE_CHOICE, MULTIPLE_CHOICE_IMAGE, SHORT_ANSWER, SHORT_ANSWER_IMAGE
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
@@ -50,6 +50,7 @@ import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.dummy.getStageTitle
 import com.paykidscompose.presentation.ui.components.ImageTooltip
 import com.paykidscompose.presentation.ui.theme.Blue1
+import com.paykidscompose.presentation.ui.theme.CardShadowElevation
 import com.paykidscompose.presentation.ui.theme.StageCardNumberTextStyle
 import com.paykidscompose.presentation.ui.theme.StageCardTitleTextStyle
 import com.paykidscompose.presentation.ui.theme.StageCircleBorderWidth
@@ -57,7 +58,6 @@ import com.paykidscompose.presentation.ui.theme.StageCircleSize
 import com.paykidscompose.presentation.ui.theme.StageDescriptionCardHeight
 import com.paykidscompose.presentation.ui.theme.StageDescriptionCardHorizontalPadding
 import com.paykidscompose.presentation.ui.theme.StageDescriptionCardRound
-import com.paykidscompose.presentation.ui.theme.StageDescriptionCardShadowElevation
 import com.paykidscompose.presentation.ui.theme.StageDescriptionCardTextHorizontalPadding
 import com.paykidscompose.presentation.ui.theme.StageDescriptionCardTextSpacer
 import com.paykidscompose.presentation.ui.theme.StageDescriptionCardTextVerticalPadding
@@ -187,7 +187,7 @@ fun HomeScreen() {
                 )
                 .height(StageDescriptionCardHeight)
                 .shadow(
-                    elevation = StageDescriptionCardShadowElevation,
+                    elevation = CardShadowElevation,
                     shape = RoundedCornerShape(StageDescriptionCardRound),
                     ambientColor = Blue1,
                     spotColor = Blue1

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
@@ -69,7 +69,7 @@ import com.paykidscompose.presentation.ui.theme.StageTooltipOffsetY
 import com.paykidscompose.presentation.ui.theme.StageTopPadding
 import com.paykidscompose.presentation.ui.theme.StageVerticalSpace
 import com.paykidscompose.presentation.ui.theme.White
-import com.paykidscompose.presentation.ui.util.getStageVisuals
+import com.paykidscompose.presentation.util.getStageVisuals
 
 private const val totalStageCount = 26
 private const val unlockedStageCount = 7

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/login/nickname/LoginNickNameScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/login/nickname/LoginNickNameScreen.kt
@@ -71,9 +71,7 @@ fun NicknameScreen(
                     user.nickname = nickname
                     DummyUser.setUser(user)
                     onConfirmClick()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
+                }
             )
         }
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -1,7 +1,5 @@
 package com.paykidscompose.presentation.screens.quiz
 
-import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,12 +20,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import coil3.compose.AsyncImage
 import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.dummy.getStageTitle
 import com.paykidscompose.presentation.ui.components.DecisionButton
-import com.paykidscompose.presentation.ui.theme.Blue2
+import com.paykidscompose.presentation.ui.components.PopupDialog
+import com.paykidscompose.presentation.ui.components.util.PopupType
+import com.paykidscompose.presentation.ui.theme.Blue1
+import com.paykidscompose.presentation.ui.theme.DeterminationButtonTextTopAndBottom2
 import com.paykidscompose.presentation.ui.theme.DeterminationTextStyle2
 import com.paykidscompose.presentation.ui.theme.Gray5
 import com.paykidscompose.presentation.ui.theme.QuizEntryButtonSpacer
@@ -47,20 +49,26 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun QuizEntryScreen() {
     var showDialog by remember { mutableStateOf(false) }
-
-    BackHandler { showDialog = true }
+    var stageNumber by remember { mutableStateOf(3) } // 임시 하드코딩
+    var stageTitle by remember { mutableStateOf(getStageTitle(stageNumber)) }
 
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
         if (showDialog) {
-
+            PopupDialog(
+                title = stringResource(R.string.dialog_incorrect_nothing),
+                popupType = PopupType.INCORRECT_ANSWER_NOTE_ERROR,
+                onCancelClick = { showDialog = false },
+                onConfirmClick = { showDialog = false },
+                description = ""
+            )
         }
 
-        Image(
-            modifier = Modifier.fillMaxSize(),
-            painter = painterResource(id = R.drawable.bg_quiz_enter),
+        AsyncImage(
+            model = R.drawable.bg_quiz_enter,
             contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Crop
         )
 
@@ -81,15 +89,15 @@ fun QuizEntryScreen() {
                     modifier = Modifier.padding(horizontal = StageNumberCardHorizontalPadding, vertical = StageNumberCardVerticalPadding),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text(text = "스테이지 3", style = StageNumberCardTextStyle)
+                    Text(text = stringResource(R.string.text_stage_number, stageNumber), style = StageNumberCardTextStyle)
                 }
             }
             Spacer(modifier = Modifier.height(QuizEntryScreenSpacer1))
 
-            Text(text = "화폐의 단위에 대해 알아보아요", style = StageTooltipTextStyle, color = White)
+            Text(text = stageTitle, style = StageTooltipTextStyle, color = White)
             Spacer(modifier = Modifier.height(QuizEntryScreenSpacer2))
 
-            DecisionButton(
+            DecisionButton( // 학습하기
                 text = stringResource(R.string.text_btn_study),
                 onClick = {
 
@@ -97,31 +105,34 @@ fun QuizEntryScreen() {
                 modifier = Modifier
                     .fillMaxWidth(),
                 backgroundColor = White,
-                contentColor = Blue2,
+                contentColor = Blue1,
+                contentPadding = DeterminationButtonTextTopAndBottom2,
                 textStyle = DeterminationTextStyle2
             )
             Spacer(modifier = Modifier.height(QuizEntryButtonSpacer))
-            DecisionButton(
+            DecisionButton( // 퀴즈 풀기
                 text = stringResource(R.string.text_btn_quiz),
                 onClick = {
 
                 },
                 modifier = Modifier
                     .fillMaxWidth(),
-                backgroundColor = Blue2,
+                backgroundColor = Blue1,
                 contentColor = White,
+                contentPadding = DeterminationButtonTextTopAndBottom2,
                 textStyle = DeterminationTextStyle2
             )
             Spacer(modifier = Modifier.height(QuizEntryButtonSpacer))
-            DecisionButton(
+            DecisionButton( // 오답노트 풀기
                 text = stringResource(R.string.text_btn_review),
                 onClick = {
-
+                    showDialog = true
                 },
                 modifier = Modifier
                     .fillMaxWidth(),
                 backgroundColor = White,
-                contentColor = Blue2,
+                contentColor = Blue1,
+                contentPadding = DeterminationButtonTextTopAndBottom2,
                 textStyle = DeterminationTextStyle2
             )
         }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -102,8 +101,6 @@ fun QuizEntryScreen() {
                 onClick = {
 
                 },
-                modifier = Modifier
-                    .fillMaxWidth(),
                 backgroundColor = White,
                 contentColor = Blue1,
                 contentPadding = DeterminationButtonTextTopAndBottom2,
@@ -115,8 +112,6 @@ fun QuizEntryScreen() {
                 onClick = {
 
                 },
-                modifier = Modifier
-                    .fillMaxWidth(),
                 backgroundColor = Blue1,
                 contentColor = White,
                 contentPadding = DeterminationButtonTextTopAndBottom2,
@@ -128,8 +123,6 @@ fun QuizEntryScreen() {
                 onClick = {
                     showDialog = true
                 },
-                modifier = Modifier
-                    .fillMaxWidth(),
                 backgroundColor = White,
                 contentColor = Blue1,
                 contentPadding = DeterminationButtonTextTopAndBottom2,

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -1,0 +1,130 @@
+package com.paykidscompose.presentation.screens.quiz
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.ui.components.DecisionButton
+import com.paykidscompose.presentation.ui.theme.Blue2
+import com.paykidscompose.presentation.ui.theme.DeterminationTextStyle2
+import com.paykidscompose.presentation.ui.theme.Gray5
+import com.paykidscompose.presentation.ui.theme.QuizEntryButtonSpacer
+import com.paykidscompose.presentation.ui.theme.QuizEntryScreenBottomPadding
+import com.paykidscompose.presentation.ui.theme.QuizEntryScreenSpacer1
+import com.paykidscompose.presentation.ui.theme.QuizEntryScreenSpacer2
+import com.paykidscompose.presentation.ui.theme.QuizEntryScreenTopPadding
+import com.paykidscompose.presentation.ui.theme.StageNumberCardHorizontalPadding
+import com.paykidscompose.presentation.ui.theme.StageNumberCardRound
+import com.paykidscompose.presentation.ui.theme.StageNumberCardTextStyle
+import com.paykidscompose.presentation.ui.theme.StageNumberCardVerticalPadding
+import com.paykidscompose.presentation.ui.theme.StageTooltipTextStyle
+import com.paykidscompose.presentation.ui.theme.StartAndEndPadding
+import com.paykidscompose.presentation.ui.theme.White
+
+@Preview(showBackground = true)
+@Composable
+fun QuizEntryScreen() {
+    var showDialog by remember { mutableStateOf(false) }
+
+    BackHandler { showDialog = true }
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        if (showDialog) {
+
+        }
+
+        Image(
+            modifier = Modifier.fillMaxSize(),
+            painter = painterResource(id = R.drawable.bg_quiz_enter),
+            contentDescription = null,
+            contentScale = ContentScale.Crop
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = StartAndEndPadding)
+                .padding(top = QuizEntryScreenTopPadding, bottom = QuizEntryScreenBottomPadding),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Card(
+                modifier = Modifier,
+                shape = RoundedCornerShape(StageNumberCardRound),
+                colors = CardDefaults.cardColors(containerColor = Gray5)
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = StageNumberCardHorizontalPadding, vertical = StageNumberCardVerticalPadding),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(text = "스테이지 3", style = StageNumberCardTextStyle)
+                }
+            }
+            Spacer(modifier = Modifier.height(QuizEntryScreenSpacer1))
+
+            Text(text = "화폐의 단위에 대해 알아보아요", style = StageTooltipTextStyle, color = White)
+            Spacer(modifier = Modifier.height(QuizEntryScreenSpacer2))
+
+            DecisionButton(
+                text = stringResource(R.string.text_btn_study),
+                onClick = {
+
+                },
+                modifier = Modifier
+                    .fillMaxWidth(),
+                backgroundColor = White,
+                contentColor = Blue2,
+                textStyle = DeterminationTextStyle2
+            )
+            Spacer(modifier = Modifier.height(QuizEntryButtonSpacer))
+            DecisionButton(
+                text = stringResource(R.string.text_btn_quiz),
+                onClick = {
+
+                },
+                modifier = Modifier
+                    .fillMaxWidth(),
+                backgroundColor = Blue2,
+                contentColor = White,
+                textStyle = DeterminationTextStyle2
+            )
+            Spacer(modifier = Modifier.height(QuizEntryButtonSpacer))
+            DecisionButton(
+                text = stringResource(R.string.text_btn_review),
+                onClick = {
+
+                },
+                modifier = Modifier
+                    .fillMaxWidth(),
+                backgroundColor = White,
+                contentColor = Blue2,
+                textStyle = DeterminationTextStyle2
+            )
+        }
+
+    }
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -1,0 +1,165 @@
+package com.paykidscompose.presentation.screens.quiz
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.model.QuizType
+import com.paykidscompose.presentation.ui.components.AppTopBar
+import com.paykidscompose.presentation.ui.theme.Black
+import com.paykidscompose.presentation.ui.theme.CardShadowElevation
+import com.paykidscompose.presentation.ui.theme.Gray3
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardImageRound
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardImageSize
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardRound
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardRowSpacer
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardSize
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardSpaceBetween
+import com.paykidscompose.presentation.ui.theme.ImageQuizCardTextSpacer
+import com.paykidscompose.presentation.ui.theme.QuizAnswerTextStyle
+import com.paykidscompose.presentation.ui.theme.QuizAppBarTextStyle
+import com.paykidscompose.presentation.ui.theme.QuizQuestionTextSpacer
+import com.paykidscompose.presentation.ui.theme.QuizQuestionTextStyle
+import com.paykidscompose.presentation.ui.theme.StartAndEndPadding
+
+@Preview(showBackground = true)
+@Composable
+fun QuizScreen(
+    onBackClick: () -> Unit = {},
+    quizType: QuizType = QuizType.IMAGE,
+    quizNumber: Int = 2,
+    totalQuizCount: Int = 7,
+    question: String = "10,000원 권 지폐에는\n어떤 인물이 그려져 있을까요?",
+    imgChoices: List<Pair<Int, String>> = listOf(
+        R.drawable.img_quiz_item_default to "세종대왕",
+        R.drawable.img_quiz_item_default to "신사임당",
+        R.drawable.img_quiz_item_default to "퇴계 이황",
+        R.drawable.img_quiz_item_default to "이순신"
+    ),
+    answer: String = "A",
+    onChoiceClick: (Int) -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = stringResource(R.string.text_quiz_number, quizNumber, totalQuizCount),
+                titleStyle = QuizAppBarTextStyle,
+                showBackButton = true,
+                onBackClick = onBackClick,
+                iconTint = Black
+            )
+        }) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    top = innerPadding.calculateTopPadding()
+                )
+        ) {
+            AsyncImage(
+                model = R.drawable.bg_quiz_default,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = StartAndEndPadding),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = question,
+                    style = QuizQuestionTextStyle,
+                    color = Black,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(QuizQuestionTextSpacer))
+
+                // 2x2 Grid: Row 2개, 각 Row 안에 2개의 선택지
+                for (row in 0 until 2) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(
+                            ImageQuizCardSpaceBetween, Alignment.CenterHorizontally
+                        ),
+                    ) {
+                        for (col in 0 until 2) {
+                            val index = row * 2 + col
+                            val (imageRes, label) = imgChoices.getOrNull(index) ?: continue
+
+                            Card(
+                                modifier = Modifier
+                                    .size(ImageQuizCardSize.first, ImageQuizCardSize.second)
+                                    .clickable { onChoiceClick(index) }
+                                    .shadow(
+                                        elevation = CardShadowElevation,
+                                        shape = RoundedCornerShape(ImageQuizCardRound),
+                                        ambientColor = Gray3,
+                                        spotColor = Gray3
+                                    ),
+                                shape = RoundedCornerShape(ImageQuizCardRound),
+                                colors = CardDefaults.cardColors(containerColor = Color.White)
+                            ) {
+                                Column(
+                                    modifier = Modifier.fillMaxSize(),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    AsyncImage(
+                                        model = imageRes,
+                                        contentDescription = label,
+                                        modifier = Modifier
+                                            .size(ImageQuizCardImageSize)
+                                            .clip(RoundedCornerShape(ImageQuizCardImageRound)),
+                                        contentScale = ContentScale.Fit,
+                                    )
+                                    Spacer(modifier = Modifier.height(ImageQuizCardTextSpacer))
+                                    Text(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        text = label,
+                                        color = Black,
+                                        style = QuizAnswerTextStyle,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(ImageQuizCardRowSpacer))
+                }
+            }
+        }
+    }
+
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.screens.quiz
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +18,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,11 +31,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.QuizType
 import com.paykidscompose.presentation.ui.components.AppTopBar
+import com.paykidscompose.presentation.ui.components.PopupDialog
+import com.paykidscompose.presentation.ui.components.util.PopupType
 import com.paykidscompose.presentation.ui.theme.Black
 import com.paykidscompose.presentation.ui.theme.CardShadowElevation
 import com.paykidscompose.presentation.ui.theme.Gray3
@@ -42,6 +48,8 @@ import com.paykidscompose.presentation.ui.theme.ImageQuizCardSize
 import com.paykidscompose.presentation.ui.theme.ImageQuizCardSpaceBetween
 import com.paykidscompose.presentation.ui.theme.ImageQuizCardTextSpacer
 import com.paykidscompose.presentation.ui.theme.QuizAnswerTextStyle
+import com.paykidscompose.presentation.ui.theme.QuizAppBarShadowColor
+import com.paykidscompose.presentation.ui.theme.QuizAppBarShadowElevation
 import com.paykidscompose.presentation.ui.theme.QuizAppBarTextStyle
 import com.paykidscompose.presentation.ui.theme.QuizQuestionTextSpacer
 import com.paykidscompose.presentation.ui.theme.QuizQuestionTextStyle
@@ -50,7 +58,6 @@ import com.paykidscompose.presentation.ui.theme.StartAndEndPadding
 @Preview(showBackground = true)
 @Composable
 fun QuizScreen(
-    onBackClick: () -> Unit = {},
     quizType: QuizType = QuizType.IMAGE,
     quizNumber: Int = 2,
     totalQuizCount: Int = 7,
@@ -64,14 +71,32 @@ fun QuizScreen(
     answer: String = "A",
     onChoiceClick: (Int) -> Unit = {}
 ) {
+    var showDialog by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = true) {
+        showDialog = true
+    }
+
+    if (showDialog) {
+        PopupDialog(
+            title = stringResource(R.string.dialog_check_exit),
+            popupType = PopupType.QUIZ_EXIT,
+            onCancelClick = { showDialog = false },
+            onConfirmClick = { showDialog = false },
+            description = ""
+        )
+    }
+
     Scaffold(
         topBar = {
             AppTopBar(
                 title = stringResource(R.string.text_quiz_number, quizNumber, totalQuizCount),
                 titleStyle = QuizAppBarTextStyle,
                 showBackButton = true,
-                onBackClick = onBackClick,
-                iconTint = Black
+                onBackClick = { showDialog = true },
+                iconTint = Black,
+                shadowColor = QuizAppBarShadowColor,
+                shadowElevation = QuizAppBarShadowElevation
             )
         }) { innerPadding ->
         Box(

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/AppTopBarComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/AppTopBarComponents.kt
@@ -6,15 +6,20 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.ui.theme.MyPageAppBarShadowColor
 import com.paykidscompose.presentation.ui.theme.MyPageAppBarTextStyle
 import com.paykidscompose.presentation.ui.theme.MyPageAppBarTitleTextColor
+import com.paykidscompose.presentation.ui.theme.TopAppBarShadowElevation
 import com.paykidscompose.presentation.ui.theme.White
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -25,9 +30,13 @@ fun AppTopBar(
     showBackButton: Boolean = false,
     onBackClick: (() -> Unit)? = null,
     painter: Painter = painterResource(R.drawable.ic_left_blue),
-    iconTint: Color = Color.Unspecified
+    iconTint: Color = Color.Unspecified,
+    shadowColor: Color = MyPageAppBarShadowColor,
+    shadowElevation: Dp = TopAppBarShadowElevation
 ) {
     CenterAlignedTopAppBar(
+        modifier = Modifier
+            .shadow(elevation = shadowElevation, ambientColor = shadowColor, spotColor = shadowColor),
         title = {
             TitleText(title, style = titleStyle, textAlign = TextAlign.Center)
         },

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/AppTopBarComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/AppTopBarComponents.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.paykidscompose.presentation.R
@@ -20,13 +21,15 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun AppTopBar(
     title: String,
+    titleStyle: TextStyle = MyPageAppBarTextStyle,
     showBackButton: Boolean = false,
     onBackClick: (() -> Unit)? = null,
-    painter: Painter = painterResource(R.drawable.ic_left_blue)
+    painter: Painter = painterResource(R.drawable.ic_left_blue),
+    iconTint: Color = Color.Unspecified
 ) {
     CenterAlignedTopAppBar(
         title = {
-            TitleText(title, style = MyPageAppBarTextStyle, textAlign = TextAlign.Center)
+            TitleText(title, style = titleStyle, textAlign = TextAlign.Center)
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
             containerColor = White,
@@ -38,7 +41,7 @@ fun AppTopBar(
                     Icon(
                         painter = painter,
                         contentDescription = null,
-                        tint = Color.Unspecified
+                        tint = iconTint
                     )
                 }
             }
@@ -50,5 +53,5 @@ fun AppTopBar(
 @Composable
 fun AppBar(
 ) {
-    AppTopBar("마이페이지", true, {})
+    AppTopBar("마이페이지",MyPageAppBarTextStyle , true, {})
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/ButtonComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/ButtonComponents.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.ui.components
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,10 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.paykidscompose.presentation.ui.theme.Blue2
 import com.paykidscompose.presentation.ui.theme.DeterminationButtonCorner
-import com.paykidscompose.presentation.ui.theme.DeterminationButtonTextStartAndEndPadding
 import com.paykidscompose.presentation.ui.theme.DeterminationButtonTextTopAndBottom
 import com.paykidscompose.presentation.ui.theme.DeterminationTextStyle
 import com.paykidscompose.presentation.ui.theme.White
@@ -25,26 +28,24 @@ fun DecisionButton(
     modifier: Modifier = Modifier,
     backgroundColor: Color = Blue2,
     contentColor: Color = White,
-    enabled: Boolean = true
-
+    enabled: Boolean = true,
+    textStyle: TextStyle = DeterminationTextStyle,
+    contentPadding: Dp = DeterminationButtonTextTopAndBottom,
 ) {
     Button(
         onClick = onClick,
         modifier = modifier
-            .padding(
-                start = DeterminationButtonTextStartAndEndPadding,
-                end = DeterminationButtonTextStartAndEndPadding,
-                top = DeterminationButtonTextTopAndBottom,
-                bottom = DeterminationButtonTextTopAndBottom
-            )
             .clip(RoundedCornerShape(DeterminationButtonCorner)),
         enabled = enabled,
         colors = ButtonDefaults.buttonColors(
-            containerColor = backgroundColor,
-            contentColor = contentColor
-        )
+            containerColor = backgroundColor, contentColor = contentColor
+        ),
+        contentPadding = PaddingValues(vertical = contentPadding)
     ) {
-        Text(text, style = DeterminationTextStyle)
+        Text(
+            text = text,
+            style = textStyle
+        )
     }
 }
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/ButtonComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/ButtonComponents.kt
@@ -2,7 +2,6 @@ package com.paykidscompose.presentation.ui.components
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -14,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.paykidscompose.presentation.ui.theme.Blue2
 import com.paykidscompose.presentation.ui.theme.DeterminationButtonCorner
 import com.paykidscompose.presentation.ui.theme.DeterminationButtonTextTopAndBottom
@@ -35,6 +33,7 @@ fun DecisionButton(
     Button(
         onClick = onClick,
         modifier = modifier
+            .fillMaxWidth()
             .clip(RoundedCornerShape(DeterminationButtonCorner)),
         enabled = enabled,
         colors = ButtonDefaults.buttonColors(
@@ -52,5 +51,5 @@ fun DecisionButton(
 @Preview
 @Composable
 fun ButtonPreview() {
-    DecisionButton("결정하기", {}, modifier = Modifier.fillMaxWidth())
+    DecisionButton("결정하기", {})
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.ui.components.util.PopupType
 import com.paykidscompose.presentation.ui.theme.Black
+import com.paykidscompose.presentation.ui.theme.Blue1
 import com.paykidscompose.presentation.ui.theme.Gray1
 import com.paykidscompose.presentation.ui.theme.Gray6
 import com.paykidscompose.presentation.ui.theme.PopupDialogButtonShape
@@ -46,10 +47,10 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun PopupDialog(
     title: String,
-    description: String,
     popupType: PopupType,
     onCancelClick: () -> Unit,
-    onConfirmClick: () -> Unit
+    onConfirmClick: () -> Unit,
+    description: String = "",
 ) {
     Dialog(
         onDismissRequest = { onCancelClick() },
@@ -81,12 +82,14 @@ fun PopupDialog(
                     style = PopupDialogTitleTextStyle.copy(color = Black)
                 )
 
-                Spacer(modifier = Modifier.height(PopupDialogSpacer8))
+                if (description != "") {
+                    Spacer(modifier = Modifier.height(PopupDialogSpacer8))
 
-                Text(
-                    text = description,
-                    style = PopupDialogTitleInfoTextStyle.copy(color = Gray1)
-                )
+                    Text(
+                        text = description,
+                        style = PopupDialogTitleInfoTextStyle.copy(color = Gray1)
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(PopupDialogSpacer20))
 
@@ -179,6 +182,50 @@ fun PopupDialog(
                             }
                         }
                     }
+
+                    PopupType.INCORRECT_ANSWER_NOTE_ERROR -> {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(IntrinsicSize.Min)
+                        ) {
+                            Button(
+                                onClick = onCancelClick,
+                                shape = RoundedCornerShape(PopupDialogButtonShape),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = Blue1, // 버튼 배경색상
+                                    contentColor = White, // 버튼 텍스트 색상
+                                )
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.dialog_enter_quiz),
+                                    style = PopupDialogButtonTextStyle
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.width(PopupDialogSpacer6))
+
+                            Button(
+                                onClick = onConfirmClick,
+                                shape = RoundedCornerShape(PopupDialogButtonShape),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = Gray6, // 버튼 배경색상
+                                    contentColor = Black, // 버튼 텍스트 색상
+                                )
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.dialog_exit),
+                                    style = PopupDialogButtonTextStyle
+                                )
+                            }
+                        }
+                    }
                 }
 
             }
@@ -189,5 +236,11 @@ fun PopupDialog(
 @Preview
 @Composable
 fun PopupDialogPreview() {
-    PopupDialog("회원 탈퇴하시겠습니까?", "이것은 테스트 팝업입니다.", PopupType.LOGOUT, {}, {})
+    PopupDialog("회원 탈퇴하시겠습니까?", PopupType.LOGOUT, {}, {}, "이것은 테스트 팝업입니다.")
+}
+
+@Preview
+@Composable
+fun PopupDialogPreview2() {
+    PopupDialog(stringResource(R.string.dialog_incorrect_nothing), PopupType.INCORRECT_ANSWER_NOTE_ERROR, {}, {}, "")
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
@@ -236,7 +236,7 @@ fun PopupDialog(
                                 .height(IntrinsicSize.Min)
                         ) {
                             Button(
-                                onClick = onConfirmClick,
+                                onClick = onCancelClick,
                                 shape = RoundedCornerShape(PopupDialogButtonShape),
                                 modifier = Modifier
                                     .weight(1f)
@@ -255,7 +255,7 @@ fun PopupDialog(
                             Spacer(modifier = Modifier.width(PopupDialogSpacer6))
 
                             Button(
-                                onClick = onCancelClick,
+                                onClick = onConfirmClick,
                                 shape = RoundedCornerShape(PopupDialogButtonShape),
                                 modifier = Modifier
                                     .weight(1f)

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -79,7 +80,8 @@ fun PopupDialog(
             ) {
                 Text(
                     text = title,
-                    style = PopupDialogTitleTextStyle.copy(color = Black)
+                    style = PopupDialogTitleTextStyle.copy(color = Black),
+                    textAlign = TextAlign.Center
                 )
 
                 if (description != "") {
@@ -190,7 +192,7 @@ fun PopupDialog(
                                 .height(IntrinsicSize.Min)
                         ) {
                             Button(
-                                onClick = onCancelClick,
+                                onClick = onConfirmClick,
                                 shape = RoundedCornerShape(PopupDialogButtonShape),
                                 modifier = Modifier
                                     .weight(1f)
@@ -209,7 +211,7 @@ fun PopupDialog(
                             Spacer(modifier = Modifier.width(PopupDialogSpacer6))
 
                             Button(
-                                onClick = onConfirmClick,
+                                onClick = onCancelClick,
                                 shape = RoundedCornerShape(PopupDialogButtonShape),
                                 modifier = Modifier
                                     .weight(1f)
@@ -221,6 +223,50 @@ fun PopupDialog(
                             ) {
                                 Text(
                                     text = stringResource(R.string.dialog_exit),
+                                    style = PopupDialogButtonTextStyle
+                                )
+                            }
+                        }
+                    }
+
+                    PopupType.QUIZ_EXIT -> {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(IntrinsicSize.Min)
+                        ) {
+                            Button(
+                                onClick = onConfirmClick,
+                                shape = RoundedCornerShape(PopupDialogButtonShape),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = Blue1, // 버튼 배경색상
+                                    contentColor = White, // 버튼 텍스트 색상
+                                )
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.dialog_continue),
+                                    style = PopupDialogButtonTextStyle
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.width(PopupDialogSpacer6))
+
+                            Button(
+                                onClick = onCancelClick,
+                                shape = RoundedCornerShape(PopupDialogButtonShape),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = Gray6, // 버튼 배경색상
+                                    contentColor = Black, // 버튼 텍스트 색상
+                                )
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.dialog_exit2),
                                     style = PopupDialogButtonTextStyle
                                 )
                             }
@@ -243,4 +289,10 @@ fun PopupDialogPreview() {
 @Composable
 fun PopupDialogPreview2() {
     PopupDialog(stringResource(R.string.dialog_incorrect_nothing), PopupType.INCORRECT_ANSWER_NOTE_ERROR, {}, {}, "")
+}
+
+@Preview
+@Composable
+fun PopupDialogPreview3() {
+    PopupDialog(stringResource(R.string.dialog_check_exit), PopupType.QUIZ_EXIT, {}, {}, "")
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/DialogComponents.kt
@@ -48,10 +48,10 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun PopupDialog(
     title: String,
+    description: String,
     popupType: PopupType,
     onCancelClick: () -> Unit,
-    onConfirmClick: () -> Unit,
-    description: String = "",
+    onConfirmClick: () -> Unit
 ) {
     Dialog(
         onDismissRequest = { onCancelClick() },
@@ -282,17 +282,17 @@ fun PopupDialog(
 @Preview
 @Composable
 fun PopupDialogPreview() {
-    PopupDialog("회원 탈퇴하시겠습니까?", PopupType.LOGOUT, {}, {}, "이것은 테스트 팝업입니다.")
+    PopupDialog("회원 탈퇴하시겠습니까?", "이것은 테스트 팝업입니다.", PopupType.LOGOUT, {}, {})
 }
 
 @Preview
 @Composable
 fun PopupDialogPreview2() {
-    PopupDialog(stringResource(R.string.dialog_incorrect_nothing), PopupType.INCORRECT_ANSWER_NOTE_ERROR, {}, {}, "")
+    PopupDialog(stringResource(R.string.dialog_incorrect_nothing), "", PopupType.INCORRECT_ANSWER_NOTE_ERROR, {}, {})
 }
 
 @Preview
 @Composable
 fun PopupDialogPreview3() {
-    PopupDialog(stringResource(R.string.dialog_check_exit), PopupType.QUIZ_EXIT, {}, {}, "")
+    PopupDialog(stringResource(R.string.dialog_check_exit), "", PopupType.QUIZ_EXIT, {}, {})
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/util/PopupType.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/util/PopupType.kt
@@ -1,5 +1,5 @@
 package com.paykidscompose.presentation.ui.components.util
 
 enum class PopupType{
-    LOGOUT, USER_DELETE
+    LOGOUT, USER_DELETE, INCORRECT_ANSWER_NOTE_ERROR
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/util/PopupType.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/util/PopupType.kt
@@ -1,5 +1,5 @@
 package com.paykidscompose.presentation.ui.components.util
 
 enum class PopupType{
-    LOGOUT, USER_DELETE, INCORRECT_ANSWER_NOTE_ERROR
+    LOGOUT, USER_DELETE, INCORRECT_ANSWER_NOTE_ERROR, QUIZ_EXIT
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Color.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Color.kt
@@ -35,3 +35,7 @@ val TitleColor = Color(0xFF222222) // 닉네임을 입력해주세요 색상이 
 // 마이페이지 색상
 val MyPageAppBarTitleTextColor = Color(0xFF000000)
 val MyPageCardShadowColor = Color(0x80CCE4FF)
+val MyPageAppBarShadowColor = Color(0x80CCE4FF)
+
+// 퀴즈 화면 색상
+val QuizAppBarShadowColor = Color(0x80DBDBDB)

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Color.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Color.kt
@@ -38,4 +38,4 @@ val MyPageCardShadowColor = Color(0x80CCE4FF)
 val MyPageAppBarShadowColor = Color(0x80CCE4FF)
 
 // 퀴즈 화면 색상
-val QuizAppBarShadowColor = Color(0x80DBDBDB)
+val QuizAppBarShadowColor = Color(0x40DBDBDB)

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -9,6 +9,7 @@ val BottomButtonPadding = 57.dp
 val DeterminationButtonPadding = 60.dp
 val DeterminationButtonTextStartAndEndPadding = 17.dp
 val DeterminationButtonTextTopAndBottom = 14.dp
+val DeterminationButtonTextTopAndBottom2 = 15.dp
 val DeterminationButtonWidth = 320.dp
 val DeterminationButtonHeight = 50.dp
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -14,6 +14,7 @@ val DeterminationButtonTextTopAndBottom2 = 15.dp
 val DeterminationButtonWidth = 320.dp
 val DeterminationButtonHeight = 50.dp
 val CardShadowElevation = 8.dp
+val TopAppBarShadowElevation = 16.dp
 
 // 스플래시 화면
 val SplashLogo = 174.dp
@@ -68,6 +69,7 @@ val ImageQuizCardImageSize = 120.dp
 val ImageQuizCardImageRound = 10.dp
 val ImageQuizCardTextSpacer = 12.dp
 val ImageQuizCardRowSpacer = 14.dp
+val QuizAppBarShadowElevation = 4.dp
 
 // 마이페이지 기본 화면
 val MyPageDefaultScreenStartEndPadding = 20.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -8,7 +8,7 @@ val DeterminationButtonCorner = 60.dp
 val BottomButtonPadding = 57.dp
 val DeterminationButtonPadding = 60.dp
 val DeterminationButtonTextStartAndEndPadding = 17.dp
-val DeterminationButtonTextTopAndBottom = 13.dp
+val DeterminationButtonTextTopAndBottom = 14.dp
 val DeterminationButtonWidth = 320.dp
 val DeterminationButtonHeight = 50.dp
 
@@ -46,6 +46,16 @@ val StageTooltipImageHeight = 80.dp
 val StageTooltipTextOffsetY = 8.dp
 const val StageTooltipOffsetX = 86
 const val StageTooltipOffsetY = 100
+
+// 퀴즈 진입 화면
+val QuizEntryScreenTopPadding = 230.dp
+val QuizEntryScreenBottomPadding = 248.dp
+val StageNumberCardRound = 100.dp
+val StageNumberCardHorizontalPadding = 10.dp
+val StageNumberCardVerticalPadding = 6.dp
+val QuizEntryScreenSpacer1 = 18.dp
+val QuizEntryScreenSpacer2 = 50.dp
+val QuizEntryButtonSpacer = 10.dp
 
 // 마이페이지 기본 화면
 val MyPageDefaultScreenStartEndPadding = 20.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.ui.theme
 
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 // 공통
@@ -12,6 +13,7 @@ val DeterminationButtonTextTopAndBottom = 14.dp
 val DeterminationButtonTextTopAndBottom2 = 15.dp
 val DeterminationButtonWidth = 320.dp
 val DeterminationButtonHeight = 50.dp
+val CardShadowElevation = 8.dp
 
 // 스플래시 화면
 val SplashLogo = 174.dp
@@ -40,7 +42,6 @@ val StageDescriptionCardHeight = 80.dp
 val StageDescriptionCardTextHorizontalPadding = 16.dp
 val StageDescriptionCardTextVerticalPadding = 20.dp
 val StageDescriptionCardTextSpacer = 7.dp
-val StageDescriptionCardShadowElevation = 8.dp
 
 val StageTooltipImageWidth = 156.dp
 val StageTooltipImageHeight = 80.dp
@@ -57,6 +58,16 @@ val StageNumberCardVerticalPadding = 6.dp
 val QuizEntryScreenSpacer1 = 18.dp
 val QuizEntryScreenSpacer2 = 50.dp
 val QuizEntryButtonSpacer = 10.dp
+
+// 퀴즈 화면
+val QuizQuestionTextSpacer = 80.dp
+val ImageQuizCardSpaceBetween = 20.dp
+val ImageQuizCardSize = Pair<Dp, Dp>(150.dp, 180.dp)
+val ImageQuizCardRound = 20.dp
+val ImageQuizCardImageSize = 120.dp
+val ImageQuizCardImageRound = 10.dp
+val ImageQuizCardTextSpacer = 12.dp
+val ImageQuizCardRowSpacer = 14.dp
 
 // 마이페이지 기본 화면
 val MyPageDefaultScreenStartEndPadding = 20.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -46,6 +46,13 @@ val DeterminationTextStyle = TextStyle(
     lineHeight = 23.sp
 )
 
+val DeterminationTextStyle2 = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 18.sp,
+    lineHeight = 20.sp
+)
+
 // 홈 스크린
 val StageCardNumberTextStyle = TextStyle(
     fontFamily = NanumSquare,
@@ -68,6 +75,15 @@ val StageTooltipTextStyle = TextStyle(
     fontWeight = FontWeight.ExtraBold,
     fontSize = 22.sp,
     lineHeight = 25.sp
+)
+
+// 퀴즈 진입 스크린
+val StageNumberCardTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 14.sp,
+    lineHeight = 16.sp,
+    color = Gray8
 )
 
 // 마이페이지 스크린

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -86,6 +86,28 @@ val StageNumberCardTextStyle = TextStyle(
     color = Gray8
 )
 
+// 퀴즈 스크린
+val QuizAppBarTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 16.sp,
+    lineHeight = 18.sp
+)
+
+val QuizQuestionTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 22.sp,
+    lineHeight = 25.sp
+)
+
+val QuizAnswerTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 18.sp,
+    lineHeight = 20.sp
+)
+
 // 마이페이지 스크린
 val MyPageAppBarTextStyle = TextStyle(
     fontFamily = NanumSquare,

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -54,14 +54,14 @@ val StageCardNumberTextStyle = TextStyle(
     lineHeight = 14.sp,
     color = Blue1
 )
-val StageCardTitleTextStyle = TextStyle(
 
 val StageTooltipTextStyle = TextStyle(
     fontFamily = NanumSquare,
     fontWeight = FontWeight.ExtraBold,
     fontSize = 22.sp,
-    lineHeight = 25.sp  
-  
+    lineHeight = 25.sp
+)
+
 // 마이페이지 스크린
 val MyPageAppBarTextStyle = TextStyle(
     fontFamily = NanumSquare,
@@ -128,19 +128,19 @@ val TermsPolicyCardItemTitleTextStyle = TextStyle(
 )
 
 // 팝업 다이얼로그
-val PopupDialogTitleTextStyle =  TextStyle(
+val PopupDialogTitleTextStyle = TextStyle(
     fontFamily = NanumSquare,
     fontWeight = FontWeight.ExtraBold,
     fontSize = 16.sp,
     lineHeight = 18.sp
 )
-val PopupDialogTitleInfoTextStyle =  TextStyle(
+val PopupDialogTitleInfoTextStyle = TextStyle(
     fontFamily = NanumSquare,
     fontWeight = FontWeight.Bold,
     fontSize = 12.sp,
     lineHeight = 26.sp
 )
-val PopupDialogButtonTextStyle =  TextStyle(
+val PopupDialogButtonTextStyle = TextStyle(
     fontFamily = NanumSquare,
     fontWeight = FontWeight.ExtraBold,
     fontSize = 14.sp,

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -55,6 +55,14 @@ val StageCardNumberTextStyle = TextStyle(
     color = Blue1
 )
 
+val StageCardTitleTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 18.sp,
+    lineHeight = 20.sp,
+    color = Black
+)
+
 val StageTooltipTextStyle = TextStyle(
     fontFamily = NanumSquare,
     fontWeight = FontWeight.ExtraBold,

--- a/presentation/src/main/java/com/paykidscompose/presentation/util/StageVisualUtil.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/util/StageVisualUtil.kt
@@ -1,4 +1,4 @@
-package com.paykidscompose.presentation.ui.util
+package com.paykidscompose.presentation.util
 
 
 import androidx.compose.ui.graphics.Color

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="text_mypage_menu">마이</string>
 
     <!-- 퀴즈 오답 노트 다이얼로그 -->
-    <string name="dialog_incorrect_nothing">틀린 문제가 없어요!\n퀴즈를 풀어보아요</string>
+    <string name="dialog_incorrect_nothing">틀린 문제가 없어요!\n퀴즈를 풀어보아요.</string>
     <string name="dialog_all_correct">모든 문제를 맞혔어요!\n복습을 해볼까요?</string>
     <string name="dialog_enter_quiz">퀴즈 풀기</string>
     <string name="dialog_exit">닫기</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="text_btn_review">오답노트 풀기</string>
 
     <!-- 퀴즈 풀기 화면 -->
+z   <string name="text_quiz_number">%1$d/%2$d</string>">
     <string name="text_correct_answer">정답이에요!</string>
     <string name="text_wrong_answer">오답이에요..</string>
     <string name="hint_input_answer">정답 입력하기...</string>


### PR DESCRIPTION
## 📝작업 내용

> 퀴즈 진입 화면 구현

## 작업 상세 내용

- [x] 퀴즈 진입 UI 구현
- [x] 오답노트 풀기 버튼 클릭 시 다이얼로그 팝업
- [x] 결정하기 버튼 컴포넌트 수정(중복 패딩 적용 안 되도록 패딩 부분 삭제)
- [x] PopupDialog description 선택적 매개변수로 변경(""를 전달하면 description 출력 안 되도록 구현)
- [x] 이미지 퀴즈 화면 구현 
- [x] 퀴즈 나가기 다이얼로그 구현
- [x] AppTopBar shadow 관련 선택적 매개변수 추가

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 1) 버튼 컴포넌트에 기본적으로 패딩이 들어가서 스크린 안의 패딩값이랑 중복 적용되길래, 버튼 컴포넌트에서 패딩 적용 안 되도록 구현했습니다. 이제 피그마 기획안이랑 버튼 길이 맞을 거예요.
> 2) AppTopBar에 그림자 넣었어요.