### PR TITLE
feat: 용돈일기 메인 화면 구현

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.paykidscompose.app.ui.theme.PayKidsComposeTheme
+import com.paykidscompose.presentation.screens.allowance.AllowanceDiaryScreen
 import com.paykidscompose.presentation.screens.login.LoginScreen
 import com.paykidscompose.presentation.screens.login.nickname.NicknameScreen
 import com.paykidscompose.presentation.screens.mypage.MyPageScreen
@@ -27,15 +28,16 @@ class MainActivity : ComponentActivity() {
         setContent {
             PayKidsComposeTheme {
                 Surface {
-                    var currentScreen by remember { mutableStateOf(Screen.SPLASH)}
-
-                    when (currentScreen) {
-                        Screen.SPLASH -> SplashScreen { currentScreen = Screen.LOGIN }
-                        Screen.LOGIN -> LoginScreen { currentScreen = Screen.NICKNAME }
-                        Screen.NICKNAME -> NicknameScreen { currentScreen = Screen.MYPAGE }
-                        Screen.MYPAGE -> MyPageScreen(onClickMyInfo = { currentScreen = Screen.MYINFO})
-                        Screen.MYINFO -> MyInfoScreen()
-                    }
+                    AllowanceDiaryScreen()
+//                    var currentScreen by remember { mutableStateOf(Screen.SPLASH)}
+//
+//                    when (currentScreen) {
+//                        Screen.SPLASH -> SplashScreen { currentScreen = Screen.LOGIN }
+//                        Screen.LOGIN -> LoginScreen { currentScreen = Screen.NICKNAME }
+//                        Screen.NICKNAME -> NicknameScreen { currentScreen = Screen.MYPAGE }
+//                        Screen.MYPAGE -> MyPageScreen(onClickMyInfo = { currentScreen = Screen.MYINFO})
+//                        Screen.MYINFO -> MyInfoScreen()
+//                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/paykidscompose/presentation/dummy/CalendarRepository.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/dummy/CalendarRepository.kt
@@ -2,6 +2,7 @@ package com.paykidscompose.presentation.dummy
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.paykidscompose.presentation.model.AllowanceType
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/dummy/DummyCalendar.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/dummy/DummyCalendar.kt
@@ -1,9 +1,7 @@
 package com.paykidscompose.presentation.dummy
 
-enum class AllowanceType{
-    INCOME, // 수입
-    EXPENSE // 소비
-}
+import com.paykidscompose.presentation.model.AllowanceType
+
 
 data class AllowanceChartCategoryDto( // 편의점 -1,800 50%
     val allowanceType: AllowanceType,

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/AllowanceDiaryUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/AllowanceDiaryUIModel.kt
@@ -1,16 +1,31 @@
 package com.paykidscompose.presentation.model
 
-import com.paykidscompose.presentation.dummy.AllowanceType
-
-
-enum class AllowanceType{
-    INCOME, // 수입
-    EXPENSE // 소비
-}
+import com.paykidscompose.presentation.dummy.AllowanceChartDTO
+import com.paykidscompose.presentation.util.formatAmount
 
 data class AllowanceDiaryUIModel(
-    val allowanceType: AllowanceType,
-    val category: String,
-    val amount: String,
+    val id: Int,
     val date: String,
-)
+    val category: String,
+    val amountFormatted: String,
+    val amount: Int,
+    val memo: String,
+    val allowanceType: AllowanceType
+): UIModel()
+
+fun AllowanceChartDTO.toUIModel(): AllowanceDiaryUIModel {
+    val formattedAmount = when (allowanceType) {
+        AllowanceType.EXPENSE -> "-${formatAmount(amount)}원"
+        AllowanceType.INCOME -> "+${formatAmount(amount)}원"
+    }
+
+    return AllowanceDiaryUIModel(
+        id = id,
+        date = date,
+        category = category,
+        amountFormatted = formattedAmount,
+        amount = amount,
+        memo = memo,
+        allowanceType = allowanceType
+    )
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/AllowanceDiaryUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/AllowanceDiaryUIModel.kt
@@ -1,0 +1,16 @@
+package com.paykidscompose.presentation.model
+
+import com.paykidscompose.presentation.dummy.AllowanceType
+
+
+enum class AllowanceType{
+    INCOME, // 수입
+    EXPENSE // 소비
+}
+
+data class AllowanceDiaryUIModel(
+    val allowanceType: AllowanceType,
+    val category: String,
+    val amount: String,
+    val date: String,
+)

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/AllowanceType.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/AllowanceType.kt
@@ -1,0 +1,6 @@
+package com.paykidscompose.presentation.model
+
+enum class AllowanceType{
+    INCOME, // 수입
+    EXPENSE // 소비
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/AllowanceDiaryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/AllowanceDiaryScreen.kt
@@ -1,0 +1,485 @@
+package com.paykidscompose.presentation.screens.allowance
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryCalendarDayTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryCalendarIncomeConsumeTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryCalendarWeekTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryDetailConsumeMonthDayTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryDetailConsumeTitleTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryHeadMonthTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryMostConsumeTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryMostConsumeTitleTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCalendarBottomPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCalendarStartEndTopPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCardShape
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenDayClickPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenDayClickSize
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenExpenseCardEndPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenExpenseCardHeight
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenExpenseCardStartPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenHeadAddIconSize
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenHeadIconSize
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer10
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer16
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer28
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer34
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer6
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer8
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenStartEndPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTopBottomPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTransactionStartEndPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTransactionTopBottomPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryTitleExpenseTextStyle
+import com.paykidscompose.presentation.ui.theme.Black
+import com.paykidscompose.presentation.ui.theme.Blue1
+import com.paykidscompose.presentation.ui.theme.Blue2
+import com.paykidscompose.presentation.ui.theme.CustomCardShadow
+import com.paykidscompose.presentation.ui.theme.Gray1
+import com.paykidscompose.presentation.ui.theme.Gray3
+import com.paykidscompose.presentation.ui.theme.Gray5
+import com.paykidscompose.presentation.ui.theme.Gray8
+import com.paykidscompose.presentation.ui.theme.MyPageCardShadowColor
+import com.paykidscompose.presentation.ui.theme.Red
+import com.paykidscompose.presentation.ui.theme.White
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.math.ceil
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun AllowanceDiaryScreen(
+) {
+    var currentMonth by remember {
+        mutableStateOf(
+            LocalDate.now().withDayOfMonth(1)
+        )
+    } // 현재 달을 저장 day를 항상 1일로 고정
+    var selectedDate by remember { mutableStateOf(LocalDate.now()) } // 선택한 날짜, 처음은 현재 날짜
+
+    val dummyData = mapOf(
+        LocalDate.of(2025, 6, 14) to listOf(-1800, -1800, -1800),
+        LocalDate.of(2025, 6, 2) to listOf(+50000, -6000, -10000)
+    )
+
+    val selectedData = dummyData[selectedDate] ?: emptyList()
+    val totalIncome = selectedData.filter { it > 0 }.sum()
+    val totalExpense = selectedData.filter { it < 0 }.sum()
+
+    val dailySummary: Map<LocalDate, Pair<Int, Int>> = dummyData.mapValues { (_, list) ->
+        val income = list.filter { it > 0 }.sum()
+        val expense = list.filter { it < 0 }.sum()
+        Pair(income, expense)
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Gray5)
+            .padding(
+                start = AllowanceDiaryScreenStartEndPadding,
+                end = AllowanceDiaryScreenStartEndPadding,
+                top = AllowanceDiaryScreenTopBottomPadding,
+                bottom = AllowanceDiaryScreenTopBottomPadding
+            ),
+    ) {
+        item {
+            // < 12월 > + 버튼
+            HeaderSection(
+                month = currentMonth,
+                onPrev = { currentMonth = currentMonth.minusMonths(1) },
+                onNext = { currentMonth = currentMonth.plusMonths(1) },
+                onAddClick = { }
+            )
+
+            Spacer(Modifier.height(AllowanceDiaryScreenSpacer28))
+
+            Column(
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    stringResource(R.string.text_month_total_consume, totalExpense),
+                    style = AllowanceDiaryTitleExpenseTextStyle
+                        .copy(color = Black)
+                )
+
+                Spacer(Modifier.height(AllowanceDiaryScreenSpacer16))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(AllowanceDiaryScreenExpenseCardHeight)
+                        .shadow(
+                            elevation = CustomCardShadow,
+                            shape = RoundedCornerShape(AllowanceDiaryScreenCardShape),
+                            ambientColor = MyPageCardShadowColor,
+                            spotColor = MyPageCardShadowColor
+                        )
+                        .background(
+                            White, shape = RoundedCornerShape(AllowanceDiaryScreenCardShape)
+                        )
+                        .padding(
+                            start = AllowanceDiaryScreenExpenseCardStartPadding,
+                            end = AllowanceDiaryScreenExpenseCardEndPadding
+                        ),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = currentMonth.format(DateTimeFormatter.ofPattern("M월 달 ")),
+                                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
+                            )
+                            Text(
+                                "편의점",
+                                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
+                            ) // 카테고리 추가 예정
+                            Text(
+                                text = stringResource(R.string.text_month_most_consume2),
+                                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
+                            )
+                        }
+
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = "$totalExpense",
+                                modifier = Modifier.weight(1f, fill = false),
+                                maxLines = 1,
+                                textAlign = TextAlign.End,
+                                style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
+                            )
+
+                            Spacer(modifier = Modifier.width(AllowanceDiaryScreenSpacer8))
+
+                            Text(
+                                stringResource(R.string.text_consuming),
+                                modifier = Modifier.wrapContentWidth(),
+                                style = AllowanceDiaryMostConsumeTextStyle
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(AllowanceDiaryScreenSpacer16))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(
+                        elevation = CustomCardShadow,
+                        ambientColor = MyPageCardShadowColor,
+                        spotColor = MyPageCardShadowColor
+                    )
+                    .background(
+                        White
+                    )
+                    .padding(
+                        start = AllowanceDiaryScreenCalendarStartEndTopPadding,
+                        end = AllowanceDiaryScreenCalendarStartEndTopPadding,
+                        top = AllowanceDiaryScreenCalendarStartEndTopPadding,
+                        bottom = AllowanceDiaryScreenCalendarBottomPadding
+                    )
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    CalendarGrid(
+                        dailySummary = dailySummary,
+                        month = currentMonth,
+                        selectedDate = selectedDate,
+                        onDateSelected = { selectedDate = it }
+                    )
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(AllowanceDiaryScreenSpacer34))
+            Text(
+                stringResource(R.string.text_detail_consume),
+                style = AllowanceDiaryDetailConsumeTitleTextStyle.copy(color = Black)
+            )
+
+            Spacer(Modifier.height(AllowanceDiaryScreenSpacer10))
+
+            Text(
+                text = selectedDate.format(DateTimeFormatter.ofPattern("M월 d일")),
+                style = AllowanceDiaryDetailConsumeMonthDayTextStyle.copy(color = Gray8)
+            )
+
+            Spacer(Modifier.height(AllowanceDiaryScreenSpacer8))
+        }
+
+        items(selectedData) { amount ->
+            TransactionItem(amount)
+            Spacer(Modifier.height(AllowanceDiaryScreenSpacer8))
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun HeaderSection(
+    month: LocalDate,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onAddClick: () -> Unit
+) {
+    val formatter = DateTimeFormatter.ofPattern("M월", Locale.KOREAN)
+
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.CenterStart
+    ) {
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = onPrev,
+                modifier = Modifier.size(AllowanceDiaryScreenHeadIconSize)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_left_round),
+                    contentDescription = null,
+                    tint = Color.Unspecified
+                )
+            }
+
+            Text(
+                text = month.format(formatter), style = AllowanceDiaryHeadMonthTextStyle
+            )
+
+            IconButton(
+                onClick = onNext,
+                modifier = Modifier.size(AllowanceDiaryScreenHeadIconSize)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_right_round),
+                    contentDescription = null,
+                    tint = Color.Unspecified
+                )
+            }
+        }
+
+        IconButton(
+            onClick = onAddClick,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .size(AllowanceDiaryScreenHeadAddIconSize)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_plus),
+                contentDescription = null,
+                tint = Color.Unspecified
+            )
+        }
+    }
+
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun CalendarGrid(
+    dailySummary: Map<LocalDate, Pair<Int, Int>>,
+    month: LocalDate,
+    selectedDate: LocalDate,
+    onDateSelected: (LocalDate) -> Unit
+) {
+    val daysOfWeek = listOf(
+        stringResource(R.string.text_week_sunday),
+        stringResource(R.string.text_week_monday),
+        stringResource(R.string.text_week_tuesday),
+        stringResource(R.string.text_week_wednesday),
+        stringResource(R.string.text_week_thursday),
+        stringResource(R.string.text_week_friday),
+        stringResource(R.string.text_week_saturday)
+    )
+    val firstDay = month.withDayOfMonth(1)
+    val daysInMonth = month.lengthOfMonth()
+    val startOffset =
+        firstDay.dayOfWeek.value % 7 // 일요일 = 0, 달력이 어느 요일 부터 시작해야하는지 계산 2025-06-01 월요일이면 1 , 시작위치는 0~6
+
+    Column {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            daysOfWeek.forEach { day ->
+                Text(
+                    text = day,
+                    modifier = Modifier
+                        .weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = AllowanceDiaryCalendarWeekTextStyle.copy(color = Gray1)
+                )
+            }
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        val rows = ceil((startOffset + daysInMonth) / 7.0).toInt() // 일주일 단위로 배치 행 계산
+        repeat(rows) { row ->
+            Row(modifier = Modifier.fillMaxWidth()) {
+                for (col in 0 until 7) { // 요일이 7개라서 열 = 7
+                    val index = row * 7 + col
+                    val day = index - startOffset + 1
+                    if (index < startOffset || day > daysInMonth) {
+                        // 빈칸처리 첫날이 수요일이라면 앞에 2칸은 빈칸이어야함.
+                        // 말일 이후 칸은 더 이상 날짜가 없음
+                        Spacer(modifier = Modifier.weight(1f))
+                    } else {
+                        val date = month.withDayOfMonth(day)
+                        val isSelected = date == selectedDate
+                        val isToday = date == LocalDate.now()
+                        val (income, expense) = dailySummary[date] ?: Pair(0, 0)
+
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(AllowanceDiaryScreenDayClickPadding)
+                                .clickable { onDateSelected(date) },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(AllowanceDiaryScreenDayClickSize) // 원 크기
+                                        .clip(CircleShape)
+                                        .background(
+                                            when {
+                                                isSelected -> Blue2
+                                                isToday -> Gray3
+                                                else -> Color.Transparent
+                                            }
+                                        ),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = day.toString(),
+                                        style = AllowanceDiaryCalendarDayTextStyle.copy(
+                                            color = if (isSelected) White else Black
+                                        )
+                                    )
+                                }
+
+                                if (income > 0) {
+                                    Text(
+                                        "+$income",
+                                        style = AllowanceDiaryCalendarIncomeConsumeTextStyle.copy(
+                                            color = Blue1
+                                        ),
+                                        maxLines = 1
+                                    )
+                                }
+
+                                if (expense < 0) {
+                                    Text(
+                                        "$expense",
+                                        style = AllowanceDiaryCalendarIncomeConsumeTextStyle.copy(
+                                            color = Red
+                                        ),
+                                        maxLines = 1
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TransactionItem(amount: Int) {
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = CustomCardShadow,
+                shape = RoundedCornerShape(AllowanceDiaryScreenCardShape),
+                ambientColor = MyPageCardShadowColor,
+                spotColor = MyPageCardShadowColor
+            )
+            .background(
+                White, shape = RoundedCornerShape(AllowanceDiaryScreenCardShape)
+            )
+            .padding(
+                start = AllowanceDiaryScreenTransactionStartEndPadding,
+                end = AllowanceDiaryScreenTransactionStartEndPadding,
+                top = AllowanceDiaryScreenTransactionTopBottomPadding,
+                bottom = AllowanceDiaryScreenTransactionTopBottomPadding
+            ),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Column {
+            Text(
+                "편의점",
+                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
+            ) // 카테고리 추가 예정
+            Spacer(Modifier.height(AllowanceDiaryScreenSpacer6))
+            Text(
+                "$amount",
+                style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
+            )
+        }
+        Text(
+            "불닭볶음면 사먹음 ㅎㅎ",
+            style = AllowanceDiaryMostConsumeTextStyle.copy(color = Gray1),
+            modifier = Modifier.align(Alignment.CenterEnd)
+        ) // 메모 추가 예정
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
+@Composable
+fun DiaryScreenPreview() {
+    AllowanceDiaryScreen()
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/AllowanceDiaryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/AllowanceDiaryScreen.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,9 +39,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.dummy.DummyDataManager
+import com.paykidscompose.presentation.model.AllowanceDiaryUIModel
+import com.paykidscompose.presentation.model.AllowanceType
+import com.paykidscompose.presentation.model.toUIModel
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryCalendarDayTextStyle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryCalendarIncomeConsumeTextStyle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryCalendarWeekTextStyle
@@ -47,6 +55,7 @@ import com.paykidscompose.presentation.ui.theme.AllowanceDiaryDetailConsumeTitle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryHeadMonthTextStyle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryMostConsumeTextStyle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryMostConsumeTitleTextStyle
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenBottomPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCalendarBottomPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCalendarStartEndTopPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCardShape
@@ -64,7 +73,7 @@ import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer34
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer6
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer8
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenStartEndPadding
-import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTopBottomPadding
+import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTopPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTransactionStartEndPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTransactionTopBottomPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryTitleExpenseTextStyle
@@ -79,6 +88,9 @@ import com.paykidscompose.presentation.ui.theme.Gray8
 import com.paykidscompose.presentation.ui.theme.MyPageCardShadowColor
 import com.paykidscompose.presentation.ui.theme.Red
 import com.paykidscompose.presentation.ui.theme.White
+import com.paykidscompose.presentation.util.formatAmount
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -88,27 +100,84 @@ import kotlin.math.ceil
 @Composable
 fun AllowanceDiaryScreen(
 ) {
+
+    val dummyDataManager = remember { DummyDataManager() }
+
+
     var currentMonth by remember {
         mutableStateOf(
             LocalDate.now().withDayOfMonth(1)
         )
     } // 현재 달을 저장 day를 항상 1일로 고정
+
+    val dateFormatterDay = remember { DateTimeFormatter.ofPattern("yyyy-MM-dd") }
+    val dateFormatterMonth = remember { DateTimeFormatter.ofPattern("yyyy-MM") }
+
     var selectedDate by remember { mutableStateOf(LocalDate.now()) } // 선택한 날짜, 처음은 현재 날짜
 
-    val dummyData = mapOf(
-        LocalDate.of(2025, 6, 14) to listOf(-1800, -1800, -1800),
-        LocalDate.of(2025, 6, 2) to listOf(+50000, -6000, -10000)
-    )
+    val allAllowanceCharts = remember { dummyDataManager.getAllAllowanceCharts() }
+    val selectedDateString = remember(selectedDate) { selectedDate.format(dateFormatterDay) }
 
-    val selectedData = dummyData[selectedDate] ?: emptyList()
-    val totalIncome = selectedData.filter { it > 0 }.sum()
-    val totalExpense = selectedData.filter { it < 0 }.sum()
-
-    val dailySummary: Map<LocalDate, Pair<Int, Int>> = dummyData.mapValues { (_, list) ->
-        val income = list.filter { it > 0 }.sum()
-        val expense = list.filter { it < 0 }.sum()
-        Pair(income, expense)
+    val selectedUIModels by remember(selectedDateString, allAllowanceCharts) {
+        derivedStateOf {
+            allAllowanceCharts
+                .filter { it.date == selectedDateString }
+                .map { it.toUIModel() }
+        }
     }
+
+    val totalExpense by remember(currentMonth, allAllowanceCharts) {
+        derivedStateOf {
+            val monthPrefix = currentMonth.format(dateFormatterMonth)
+            allAllowanceCharts
+                .filter {
+                    it.allowanceType == AllowanceType.EXPENSE && it.date.startsWith(
+                        monthPrefix
+                    )
+                }
+                .sumOf { it.amount }
+        }
+    }
+
+    // 달력에 보여줄 수입/지출 합계
+    val dailySummary by remember(allAllowanceCharts) {
+        derivedStateOf {
+            allAllowanceCharts
+                .groupBy { LocalDate.parse(it.date) }
+                .mapValues { (_, list) ->
+                    val income =
+                        list.filter { it.allowanceType == AllowanceType.INCOME }.sumOf { it.amount }
+                    val expense = list.filter { it.allowanceType == AllowanceType.EXPENSE }
+                        .sumOf { it.amount }
+                    income to expense
+                }
+        }
+    }
+
+    // 최대 소비 카테고리, 소비 금액 계산
+    var maxExpenseCategoryAndAmount by remember { mutableStateOf<Pair<String, Int>?>(null) }
+
+    LaunchedEffect(currentMonth, allAllowanceCharts) {
+        withContext(Dispatchers.Default) {
+            val monthPrefix = currentMonth.format(dateFormatterMonth)
+            val expenseByCategory = allAllowanceCharts
+                .filter {
+                    it.allowanceType == AllowanceType.EXPENSE && it.date.startsWith(
+                        monthPrefix
+                    )
+                }
+                .groupBy { it.category }
+                .mapValues { entry -> entry.value.sumOf { it.amount } }
+
+            val max = expenseByCategory.maxByOrNull { it.value }
+            withContext(Dispatchers.Main) {
+                maxExpenseCategoryAndAmount = max?.let { it.key to it.value }
+            }
+        }
+    }
+
+    val maxCategory = maxExpenseCategoryAndAmount?.first ?: ""
+    val maxAmount = maxExpenseCategoryAndAmount?.second ?: 0
 
     LazyColumn(
         modifier = Modifier
@@ -117,8 +186,8 @@ fun AllowanceDiaryScreen(
             .padding(
                 start = AllowanceDiaryScreenStartEndPadding,
                 end = AllowanceDiaryScreenStartEndPadding,
-                top = AllowanceDiaryScreenTopBottomPadding,
-                bottom = AllowanceDiaryScreenTopBottomPadding
+                top = AllowanceDiaryScreenTopPadding,
+                bottom = AllowanceDiaryScreenBottomPadding
             ),
     ) {
         item {
@@ -136,7 +205,7 @@ fun AllowanceDiaryScreen(
                 horizontalAlignment = Alignment.Start
             ) {
                 Text(
-                    stringResource(R.string.text_month_total_consume, totalExpense),
+                    stringResource(R.string.text_month_total_consume, formatAmount(totalExpense)),
                     style = AllowanceDiaryTitleExpenseTextStyle
                         .copy(color = Black)
                 )
@@ -167,38 +236,48 @@ fun AllowanceDiaryScreen(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (maxCategory.isNotEmpty() && maxAmount > 0) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = currentMonth.format(DateTimeFormatter.ofPattern("M월 달 ")),
+                                    style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
+                                )
+
+                                Text(
+                                    maxCategory,
+                                    style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
+                                )
+
+                                Text(
+                                    text = stringResource(R.string.text_month_most_consume2),
+                                    style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
+                                )
+                            }
+
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = formatAmount(maxAmount),
+                                    modifier = Modifier.weight(1f, fill = false),
+                                    maxLines = 1,
+                                    textAlign = TextAlign.End,
+                                    style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
+                                )
+
+                                Spacer(modifier = Modifier.width(AllowanceDiaryScreenSpacer8))
+
+                                Text(
+                                    stringResource(R.string.text_consuming),
+                                    modifier = Modifier.wrapContentWidth(),
+                                    style = AllowanceDiaryMostConsumeTextStyle
+                                )
+                            }
+                        } else {
                             Text(
-                                text = currentMonth.format(DateTimeFormatter.ofPattern("M월 달 ")),
-                                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
-                            )
-                            Text(
-                                "편의점",
+                                stringResource(R.string.text_month_no_consume),
                                 style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
-                            ) // 카테고리 추가 예정
-                            Text(
-                                text = stringResource(R.string.text_month_most_consume2),
-                                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
                             )
                         }
 
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = "$totalExpense",
-                                modifier = Modifier.weight(1f, fill = false),
-                                maxLines = 1,
-                                textAlign = TextAlign.End,
-                                style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
-                            )
-
-                            Spacer(modifier = Modifier.width(AllowanceDiaryScreenSpacer8))
-
-                            Text(
-                                stringResource(R.string.text_consuming),
-                                modifier = Modifier.wrapContentWidth(),
-                                style = AllowanceDiaryMostConsumeTextStyle
-                            )
-                        }
                     }
                 }
             }
@@ -254,8 +333,8 @@ fun AllowanceDiaryScreen(
             Spacer(Modifier.height(AllowanceDiaryScreenSpacer8))
         }
 
-        items(selectedData) { amount ->
-            TransactionItem(amount)
+        items(selectedUIModels) { item ->
+            TransactionItem(item)
             Spacer(Modifier.height(AllowanceDiaryScreenSpacer8))
         }
     }
@@ -379,7 +458,11 @@ fun CalendarGrid(
                             modifier = Modifier
                                 .weight(1f)
                                 .padding(AllowanceDiaryScreenDayClickPadding)
-                                .clickable { onDateSelected(date) },
+                                .clickable(
+                                    indication = null,
+                                    interactionSource = remember { MutableInteractionSource() }) {
+                                    onDateSelected(date)
+                                },
                             contentAlignment = Alignment.Center
                         ) {
                             Column(
@@ -417,9 +500,9 @@ fun CalendarGrid(
                                     )
                                 }
 
-                                if (expense < 0) {
+                                if (expense > 0) {
                                     Text(
-                                        "$expense",
+                                        "-$expense",
                                         style = AllowanceDiaryCalendarIncomeConsumeTextStyle.copy(
                                             color = Red
                                         ),
@@ -436,7 +519,7 @@ fun CalendarGrid(
 }
 
 @Composable
-fun TransactionItem(amount: Int) {
+fun TransactionItem(item: AllowanceDiaryUIModel) {
 
     Box(
         modifier = Modifier
@@ -460,19 +543,21 @@ fun TransactionItem(amount: Int) {
     ) {
         Column {
             Text(
-                "편의점",
+                item.category,
                 style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
             ) // 카테고리 추가 예정
             Spacer(Modifier.height(AllowanceDiaryScreenSpacer6))
             Text(
-                "$amount",
+                item.amountFormatted,
                 style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
             )
         }
         Text(
-            "불닭볶음면 사먹음 ㅎㅎ",
+            item.memo,
             style = AllowanceDiaryMostConsumeTextStyle.copy(color = Gray1),
-            modifier = Modifier.align(Alignment.CenterEnd)
+            modifier = Modifier.align(Alignment.CenterEnd),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         ) // 메모 추가 예정
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -110,3 +110,27 @@ val PopupDialogSpacer6 = 6.dp
 val PopupDialogSpacer8 = 8.dp
 val PopupDialogSpacer20 = 20.dp
 val PopupDialogButtonShape = 10.dp
+
+
+// 용돈일기 화면
+val AllowanceDiaryScreenTopBottomPadding = 20.dp
+val AllowanceDiaryScreenStartEndPadding = 17.dp
+val AllowanceDiaryScreenCardShape = 10.dp
+val AllowanceDiaryScreenSpacer4 = 4.dp
+val AllowanceDiaryScreenSpacer6 = 6.dp
+val AllowanceDiaryScreenSpacer8 = 8.dp
+val AllowanceDiaryScreenSpacer10 = 10.dp
+val AllowanceDiaryScreenSpacer16 = 16.dp
+val AllowanceDiaryScreenSpacer34 = 34.dp
+val AllowanceDiaryScreenSpacer28 = 28.dp
+val AllowanceDiaryScreenExpenseCardHeight = 60.dp
+val AllowanceDiaryScreenExpenseCardStartPadding = 18.dp
+val AllowanceDiaryScreenExpenseCardEndPadding = 23.dp
+val AllowanceDiaryScreenCalendarStartEndTopPadding = 12.dp
+val AllowanceDiaryScreenCalendarBottomPadding = 56.dp
+val AllowanceDiaryScreenHeadIconSize = 22.dp
+val AllowanceDiaryScreenHeadAddIconSize = 15.dp
+val AllowanceDiaryScreenDayClickPadding = 4.dp
+val AllowanceDiaryScreenDayClickSize = 32.dp
+val AllowanceDiaryScreenTransactionStartEndPadding = 18.dp
+val AllowanceDiaryScreenTransactionTopBottomPadding = 18.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -113,7 +113,8 @@ val PopupDialogButtonShape = 10.dp
 
 
 // 용돈일기 화면
-val AllowanceDiaryScreenTopBottomPadding = 20.dp
+val AllowanceDiaryScreenTopPadding = 44.dp
+val AllowanceDiaryScreenBottomPadding = 80.dp
 val AllowanceDiaryScreenStartEndPadding = 17.dp
 val AllowanceDiaryScreenCardShape = 10.dp
 val AllowanceDiaryScreenSpacer4 = 4.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -22,6 +22,28 @@ val InfoTextStyle = TextStyle(
     lineHeight = 14.sp
 )
 
+// 홈 스크린
+val StageCardNumberTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 12.sp,
+    lineHeight = 14.sp,
+    color = Blue1
+)
+val StageCardTitleTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 18.sp,
+    lineHeight = 20.sp,
+    color = Black
+)
+
+val StageTooltipTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 22.sp,
+    lineHeight = 25.sp
+)
 
 // 닉네임 스크린
 val NicknameTitleTextStyle = TextStyle(
@@ -46,22 +68,6 @@ val DeterminationTextStyle = TextStyle(
     lineHeight = 23.sp
 )
 
-// 홈 스크린
-val StageCardNumberTextStyle = TextStyle(
-    fontFamily = NanumSquare,
-    fontWeight = FontWeight.ExtraBold,
-    fontSize = 12.sp,
-    lineHeight = 14.sp,
-    color = Blue1
-)
-val StageCardTitleTextStyle = TextStyle(
-
-val StageTooltipTextStyle = TextStyle(
-    fontFamily = NanumSquare,
-    fontWeight = FontWeight.ExtraBold,
-    fontSize = 22.sp,
-    lineHeight = 25.sp  
-  
 // 마이페이지 스크린
 val MyPageAppBarTextStyle = TextStyle(
     fontFamily = NanumSquare,
@@ -145,4 +151,62 @@ val PopupDialogButtonTextStyle =  TextStyle(
     fontWeight = FontWeight.ExtraBold,
     fontSize = 14.sp,
     lineHeight = 16.sp
+)
+
+// 용돈일기 스크린
+
+val AllowanceDiaryTitleExpenseTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 20.sp,
+    lineHeight = 23.sp
+)
+val AllowanceDiaryMostConsumeTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 11.sp,
+    lineHeight = 12.sp
+)
+val AllowanceDiaryMostConsumeTitleTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 16.sp,
+    lineHeight = 18.sp
+)
+val AllowanceDiaryDetailConsumeTitleTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 18.sp,
+    lineHeight = 20.sp
+)
+val AllowanceDiaryDetailConsumeMonthDayTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 12.sp,
+    lineHeight = 14.sp
+)
+val AllowanceDiaryHeadMonthTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 16.sp,
+    lineHeight = 18.sp
+)
+val AllowanceDiaryCalendarDayTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 16.sp,
+    lineHeight = 26.sp,
+)
+val AllowanceDiaryCalendarIncomeConsumeTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 10.sp,
+    lineHeight = 13.sp
+)
+
+val AllowanceDiaryCalendarWeekTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 14.sp,
+    lineHeight = 26.sp
 )

--- a/presentation/src/main/java/com/paykidscompose/presentation/util/MoneyUtils.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/util/MoneyUtils.kt
@@ -1,0 +1,5 @@
+package com.paykidscompose.presentation.util
+
+fun formatAmount(amount: Int): String {
+    return "%,d".format(kotlin.math.abs(amount))
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <!-- 용돈 일기 페이지 -->
     <string name="text_month_total_consume">%s원 사용 중</string>
     <string name="text_month_most_consume">%d월 달 %s에서 소비를 많이 했어요</string>
+    <string name="text_month_most_consume2">에서 소비를 많이 했어요</string>
     <string name="text_consuming">소비 중</string>
     <string name="text_detail_consume">상세 소비내역</string>
     <string name="text_week_sunday">일</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="text_month_total_consume">%s원 사용 중</string>
     <string name="text_month_most_consume">%d월 달 %s에서 소비를 많이 했어요</string>
     <string name="text_month_most_consume2">에서 소비를 많이 했어요</string>
+    <string name="text_month_no_consume">이번 달에는 소비 내역이 없습니다.</string>
     <string name="text_consuming">소비 중</string>
     <string name="text_detail_consume">상세 소비내역</string>
     <string name="text_week_sunday">일</string>


### PR DESCRIPTION
## 📝작업 내용

> 용돈일기 메인 화면 구현했습니다.

## 작업 상세 내용

- [x] UIModel 사용
- [x] 필요한 리소스 추가
- [x] 캘린더 더미 사용
- [x] 카테고리, 소비, 수입 잘 반영됩니다.

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/91e774dc-2199-4183-815b-1c6b43387193" width="200" height="400"/>