### PR TITLE
feat: 카테고리 상세내역 화면 구현했습니다.

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/AllowanceDiaryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/AllowanceDiaryScreen.kt
@@ -36,10 +36,12 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.dummy.DummyDataManager
 import com.paykidscompose.presentation.model.AllowanceDiaryUIModel
@@ -88,12 +90,14 @@ import com.paykidscompose.presentation.ui.theme.Gray8
 import com.paykidscompose.presentation.ui.theme.MyPageCardShadowColor
 import com.paykidscompose.presentation.ui.theme.Red
 import com.paykidscompose.presentation.ui.theme.White
+import com.paykidscompose.presentation.util.DateFormatterDay
+import com.paykidscompose.presentation.util.DateFormatterMonth
+import com.paykidscompose.presentation.util.MonthFormatter
 import com.paykidscompose.presentation.util.formatAmount
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import java.util.Locale
 import kotlin.math.ceil
 
 @Composable
@@ -113,13 +117,10 @@ fun AllowanceDiaryScreen(
         )
     } // 현재 달을 저장 day를 항상 1일로 고정
 
-    val dateFormatterDay = remember { DateTimeFormatter.ofPattern("yyyy-MM-dd") }
-    val dateFormatterMonth = remember { DateTimeFormatter.ofPattern("yyyy-MM") }
-
     var selectedDate by remember { mutableStateOf(LocalDate.now()) } // 선택한 날짜, 처음은 현재 날짜
 
     val allAllowanceCharts = remember { dummyDataManager.getAllAllowanceCharts() }
-    val selectedDateString = remember(selectedDate) { selectedDate.format(dateFormatterDay) }
+    val selectedDateString = remember(selectedDate) { selectedDate.format(DateFormatterDay) }
 
     val selectedUIModels by remember(selectedDateString, allAllowanceCharts) {
         derivedStateOf {
@@ -131,7 +132,7 @@ fun AllowanceDiaryScreen(
 
     val totalExpense by remember(currentMonth, allAllowanceCharts) {
         derivedStateOf {
-            val monthPrefix = currentMonth.format(dateFormatterMonth)
+            val monthPrefix = currentMonth.format(DateFormatterMonth)
             allAllowanceCharts
                 .filter {
                     it.allowanceType == AllowanceType.EXPENSE && it.date.startsWith(
@@ -162,7 +163,7 @@ fun AllowanceDiaryScreen(
 
     LaunchedEffect(currentMonth, allAllowanceCharts) {
         withContext(Dispatchers.Default) {
-            val monthPrefix = currentMonth.format(dateFormatterMonth)
+            val monthPrefix = currentMonth.format(DateFormatterMonth)
             val expenseByCategory = allAllowanceCharts
                 .filter {
                     it.allowanceType == AllowanceType.EXPENSE && it.date.startsWith(
@@ -174,7 +175,8 @@ fun AllowanceDiaryScreen(
 
             val max = expenseByCategory.maxByOrNull { it.value }
             withContext(Dispatchers.Main) {
-                maxExpenseCategoryAndAmount = max?.let { it.key to it.value } // 상태를 업데이트 하는거라서 메인 스레드에서 돼야함.
+                maxExpenseCategoryAndAmount =
+                    max?.let { it.key to it.value } // 상태를 업데이트 하는거라서 메인 스레드에서 돼야함.
             }
         }
     }
@@ -188,7 +190,7 @@ fun AllowanceDiaryScreen(
         showInputDialog = value
     }
 
-    if(showInputDialog) {
+    if (showInputDialog) {
         AllowanceInputDialog(
             onSelect = {},
             onCancelClick = { showInputDialog = false }
@@ -247,55 +249,48 @@ fun AllowanceDiaryScreen(
                             start = AllowanceDiaryScreenExpenseCardStartPadding,
                             end = AllowanceDiaryScreenExpenseCardEndPadding
                         ),
-                    contentAlignment = Alignment.CenterStart
+                    contentAlignment = Alignment.CenterStart,
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        if (maxCategory.isNotEmpty() && maxAmount > 0) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = currentMonth.format(DateTimeFormatter.ofPattern("M월 달 ")),
-                                    style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
-                                )
+                    if (maxCategory.isNotEmpty() && maxAmount > 0) {
+                        Text(
+                            buildAnnotatedString {
+                                withStyle(SpanStyle(color = Black)) {
+                                    append(currentMonth.format(DateTimeFormatter.ofPattern("M월 달 ")))
+                                }
+                                withStyle(SpanStyle(color = Blue1)) {
+                                    append(maxCategory)
+                                }
+                                withStyle(SpanStyle(color = Black)) {
+                                    append(stringResource(R.string.text_month_most_consume2))
+                                }
+                            },
+                            style = AllowanceDiaryMostConsumeTextStyle
+                        )
 
-                                Text(
-                                    maxCategory,
-                                    style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
-                                )
-
-                                Text(
-                                    text = stringResource(R.string.text_month_most_consume2),
-                                    style = AllowanceDiaryMostConsumeTextStyle.copy(color = Black)
-                                )
-                            }
-
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = formatAmount(maxAmount),
-                                    modifier = Modifier.weight(1f, fill = false),
-                                    maxLines = 1,
-                                    textAlign = TextAlign.End,
-                                    style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
-                                )
-
-                                Spacer(modifier = Modifier.width(AllowanceDiaryScreenSpacer8))
-
-                                Text(
-                                    stringResource(R.string.text_consuming),
-                                    modifier = Modifier.wrapContentWidth(),
-                                    style = AllowanceDiaryMostConsumeTextStyle
-                                )
-                            }
-                        } else {
+                        Row(
+                            modifier = Modifier.align(Alignment.CenterEnd)
+                        ) {
                             Text(
-                                stringResource(R.string.text_month_no_consume),
-                                style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
+                                text = formatAmount(maxAmount),
+                                modifier = Modifier.weight(1f, fill = false),
+                                maxLines = 1,
+                                textAlign = TextAlign.End,
+                                style = AllowanceDiaryMostConsumeTitleTextStyle.copy(color = Black)
+                            )
+
+                            Spacer(modifier = Modifier.width(AllowanceDiaryScreenSpacer8))
+
+                            Text(
+                                stringResource(R.string.text_consuming),
+                                modifier = Modifier.wrapContentWidth(),
+                                style = AllowanceDiaryMostConsumeTextStyle
                             )
                         }
-
+                    } else {
+                        Text(
+                            stringResource(R.string.text_month_no_consume),
+                            style = AllowanceDiaryMostConsumeTextStyle.copy(color = Blue1)
+                        )
                     }
                 }
             }
@@ -365,8 +360,6 @@ fun HeaderSection(
     onNext: () -> Unit,
     onAddClick: () -> Unit
 ) {
-    val formatter = DateTimeFormatter.ofPattern("M월", Locale.KOREAN)
-
     Box(
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.CenterStart
@@ -387,7 +380,7 @@ fun HeaderSection(
             }
 
             Text(
-                text = month.format(formatter), style = AllowanceDiaryHeadMonthTextStyle
+                text = month.format(MonthFormatter), style = AllowanceDiaryHeadMonthTextStyle
             )
 
             IconButton(
@@ -535,7 +528,11 @@ fun CalendarGrid(
 }
 
 @Composable
-fun TransactionItem(item: AllowanceDiaryUIModel, showInputDialog: Boolean, onShowDialog: (Boolean)-> Unit) {
+fun TransactionItem(
+    item: AllowanceDiaryUIModel,
+    showInputDialog: Boolean,
+    onShowDialog: (Boolean) -> Unit
+) {
 
     Box(
         modifier = Modifier

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/ExpenseAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/ExpenseAnalysisScreen.kt
@@ -39,23 +39,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.dummy.AllowanceChartDTO
-import com.paykidscompose.presentation.model.AllowanceDiaryUIModel
 import com.paykidscompose.presentation.model.AllowanceType
 import com.paykidscompose.presentation.ui.components.AllowanceInputDialog
-import com.paykidscompose.presentation.ui.components.CustomCard
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryHeadMonthTextStyle
-import com.paykidscompose.presentation.ui.theme.AllowanceDiaryMostConsumeTextStyle
-import com.paykidscompose.presentation.ui.theme.AllowanceDiaryMostConsumeTitleTextStyle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCardShape
-import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenHeadAddIconSize
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenHeadIconSize
-import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenSpacer6
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTransactionStartEndPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenTransactionTopBottomPadding
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryTitleExpenseTextStyle
@@ -82,10 +75,8 @@ import com.paykidscompose.presentation.ui.theme.MyPageCardShadowColor
 import com.paykidscompose.presentation.ui.theme.White
 import com.paykidscompose.presentation.ui.theme.White2
 import com.paykidscompose.presentation.util.formatAmount
-import com.paykidscompose.presentation.util.monthFormatter
+import com.paykidscompose.presentation.util.MonthFormatter
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import kotlin.collections.filter
 
 @Composable
@@ -168,7 +159,7 @@ fun ExpenseAnalysisScreen(
             }
 
             Text(
-                text = month.format(monthFormatter), style = AllowanceDiaryHeadMonthTextStyle
+                text = month.format(MonthFormatter), style = AllowanceDiaryHeadMonthTextStyle
             )
 
             IconButton(
@@ -351,7 +342,7 @@ fun AnalysisItem(
             .fillMaxWidth()
             .clickable(
                 onClick = {
-                    onShowDialog(!showInputDialog)
+                    // CategoryDetailScreen으로 이동
                 }
             )
             .shadow(

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/detail/CategoryDetailScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/detail/CategoryDetailScreen.kt
@@ -1,0 +1,235 @@
+package com.paykidscompose.presentation.screens.allowance.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.ui.components.AllowanceInputDialog
+import com.paykidscompose.presentation.ui.theme.Black
+import com.paykidscompose.presentation.ui.theme.Blue1
+import com.paykidscompose.presentation.ui.theme.CategoryDetailItemAddTextStyle
+import com.paykidscompose.presentation.ui.theme.CategoryDetailItemAmountTextStyle
+import com.paykidscompose.presentation.ui.theme.CategoryDetailItemCategoryTextStyle
+import com.paykidscompose.presentation.ui.theme.CategoryDetailItemMemoTextStyle
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenItemStartEndPadding
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenItemTopBottomPadding
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenSpacer24
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenSpacer6
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenSpacer8
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenStartEndPadding
+import com.paykidscompose.presentation.ui.theme.CategoryDetailScreenTopPadding
+import com.paykidscompose.presentation.ui.theme.CategoryDetailTitleTextStyle
+import com.paykidscompose.presentation.ui.theme.Gray1
+import com.paykidscompose.presentation.ui.theme.Gray5
+import com.paykidscompose.presentation.ui.theme.Gray7
+import com.paykidscompose.presentation.ui.theme.MyPageCardShadowColor
+import com.paykidscompose.presentation.ui.theme.ShadowElevation16
+import com.paykidscompose.presentation.ui.theme.Shape10
+import com.paykidscompose.presentation.ui.theme.White
+import com.paykidscompose.presentation.ui.theme.White2
+import com.paykidscompose.presentation.util.formatAmount
+
+data class DetailTestModel(
+    val category: String,
+    val amount: Int,
+    val memo: String
+)
+
+@Composable
+fun CategoryDetail(
+
+) {
+    val category = "편의점" // uimodel로 다 바꿀겁니다. 지금은 정적인 화면 구현 중입니다.
+    val amount = 150000
+
+    val details = listOf(
+        DetailTestModel("편의점", 1800, "불닭 사먹음 ㅎㅎ"),
+        DetailTestModel("편의점", 4000, "도시락 사먹음 ㅎㅎ"),
+        DetailTestModel("편의점", 2000, "음료수 사먹음 ㅎㅎ")
+    )
+
+    var showDialog by remember { mutableStateOf(false)}
+
+    val onDialog = { value: Boolean ->
+        showDialog = value
+    }
+
+    CategoryDetailScreen(
+        category = category,
+        amount = amount,
+        details = details,
+        showDialog = showDialog,
+        onDialog = onDialog
+    )
+}
+
+@Composable
+fun CategoryDetailScreen(
+    category: String,
+    amount: Int,
+    showDialog: Boolean,
+    onDialog: (Boolean) -> Unit,
+    details: List<DetailTestModel>
+) {
+    if(showDialog) {
+        AllowanceInputDialog(
+            onSelect = {},
+            onCancelClick = {
+                onDialog(!showDialog)
+            },
+            onConfirmClick = {
+                onDialog(!showDialog)
+            }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Gray5)
+            .padding(
+                start = CategoryDetailScreenStartEndPadding,
+                end = CategoryDetailScreenStartEndPadding,
+                top = CategoryDetailScreenTopPadding
+            )
+    ) {
+        Text(
+            buildAnnotatedString {
+                withStyle(SpanStyle(color = Blue1)) {
+                    append(category)
+                }
+                withStyle(SpanStyle(color = Black)) {
+                    append(
+                        stringResource(R.string.text_category_consume,
+                        formatAmount(amount)))
+                }
+            },
+            style = CategoryDetailTitleTextStyle
+        )
+
+        Spacer(Modifier.height(CategoryDetailScreenSpacer24))
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items(details) {
+                DetailItem(it, showDialog, onDialog)
+
+                Spacer(Modifier.height(CategoryDetailScreenSpacer8))
+            }
+
+            item {
+                // 나중에 재사용할 수 있게 만들어야 할 거 같습니다.
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(Shape10)
+                        .clickable(
+                            onClick = {
+                                // 추가하기 로직 추가 예정
+                            }
+                        )
+                        .background(color = White2)
+                        .shadow(
+                            elevation = ShadowElevation16,
+                            shape = Shape10,
+                            ambientColor = MyPageCardShadowColor,
+                            spotColor = MyPageCardShadowColor
+                        )
+                        .padding(top = CategoryDetailScreenItemTopBottomPadding,
+                            bottom = CategoryDetailScreenItemTopBottomPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        stringResource(R.string.text_add_category),
+                        style = CategoryDetailItemAddTextStyle.copy(color = Gray7)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DetailItem(
+    data: DetailTestModel,
+    showDialog: Boolean,
+    onDialog: (Boolean) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(Shape10)
+            .clickable(
+                onClick = {
+                    // 수정하는 화면으로 이동 로직 추가 예정
+                    onDialog(!showDialog)
+                }
+            )
+            .background(color = White)
+            .shadow(
+                elevation = ShadowElevation16,
+                shape = Shape10,
+                ambientColor = MyPageCardShadowColor,
+                spotColor = MyPageCardShadowColor
+            )
+            .padding(start = CategoryDetailScreenItemStartEndPadding,
+                end = CategoryDetailScreenItemStartEndPadding,
+                top = CategoryDetailScreenItemTopBottomPadding,
+                bottom = CategoryDetailScreenItemTopBottomPadding)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                Text(
+                    data.category,
+                    style = CategoryDetailItemCategoryTextStyle.copy(color = Blue1)
+                )
+                Spacer(Modifier.height(CategoryDetailScreenSpacer6))
+
+                Text(
+                    "-${formatAmount(data.amount)}",
+                    style = CategoryDetailItemAmountTextStyle.copy(color = Black)
+                )
+            }
+
+            Text(
+                data.memo,
+                style = CategoryDetailItemMemoTextStyle.copy(color = Gray1)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CategoryDetailScreenPreview() {
+    CategoryDetail()
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.ui.theme
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -8,13 +9,12 @@ val StartAndEndPadding = 20.dp
 val DeterminationButtonCorner = 60.dp
 val BottomButtonPadding = 57.dp
 val DeterminationButtonPadding = 60.dp
-val DeterminationButtonTextStartAndEndPadding = 17.dp
 val DeterminationButtonTextTopAndBottom = 14.dp
 val DeterminationButtonTextTopAndBottom2 = 15.dp
-val DeterminationButtonWidth = 320.dp
-val DeterminationButtonHeight = 50.dp
 val CardShadowElevation = 8.dp
 val TopAppBarShadowElevation = 16.dp
+val Shape10 = RoundedCornerShape(10.dp)
+val ShadowElevation16 = 16.dp
 
 // 스플래시 화면
 val SplashLogo = 174.dp
@@ -96,7 +96,6 @@ val MyInfoScreenSpacer24 = 24.dp
 val MyInfoScreenSpacer36 = 36.dp
 val MyInfoScreenSpacer38 = 38.dp
 val MyInfoScreenSpacer73 = 73.dp
-val MyInfoScreenSpacer166 = 166.dp
 val MyInfoScreenShapeTop = 20.dp
 val MyInfoScreenShapeBottom = 0.dp
 val MyInfoScreenMyInfoTopBottomPadding= 26.dp
@@ -116,9 +115,7 @@ val TermsScreenCardShapeTopBottom = 10.dp
 
 // 커스텀 카드
 val CustomCardShadow = 16.dp
-val CustomCardSizeWidth = 320.dp
 val CustomCardSizeHeight = 240.dp
-val CustomCardBackgroundShape= 10.dp
 
 // 아웃라인 인풋 필드
 val OutlineBorder = 1.dp
@@ -189,3 +186,12 @@ val AllowanceInputDialogIconWidth = 9.dp
 val AllowanceInputDialogIconHeight = 6.dp
 val AllowanceInputDialogDateItemStartEndPadding = 8.dp
 val AllowanceInputDialogDateItemTopBottomPadding = 4.dp
+
+// 카테고리 상세내역 화면
+val CategoryDetailScreenStartEndPadding = 17.dp
+val CategoryDetailScreenTopPadding = 70.dp
+val CategoryDetailScreenItemTopBottomPadding = 14.dp
+val CategoryDetailScreenItemStartEndPadding = 18.dp
+val CategoryDetailScreenSpacer6 = 6.dp
+val CategoryDetailScreenSpacer8 = 8.dp
+val CategoryDetailScreenSpacer24 = 24.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -314,3 +314,35 @@ val ExpenseAnalysisItemAddButtonTextStyle = TextStyle(
     fontSize = 16.sp,
     lineHeight = 18.sp
 )
+
+// 카테고리 세부내역 스크린
+val CategoryDetailTitleTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 20.sp,
+    lineHeight = 23.sp
+)
+val CategoryDetailItemCategoryTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 11.sp,
+    lineHeight = 12.sp
+)
+val CategoryDetailItemAmountTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 16.sp,
+    lineHeight = 18.sp
+)
+val CategoryDetailItemMemoTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 11.sp,
+    lineHeight = 12.sp
+)
+val CategoryDetailItemAddTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.ExtraBold,
+    fontSize = 16.sp,
+    lineHeight = 18.sp
+)

--- a/presentation/src/main/java/com/paykidscompose/presentation/util/FormatUtils.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/util/FormatUtils.kt
@@ -4,7 +4,9 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 
-val monthFormatter = DateTimeFormatter.ofPattern("M월", Locale.KOREAN)
+val MonthFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("M월", Locale.KOREAN)
+val DateFormatterDay: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+val DateFormatterMonth: DateTimeFormatter =  DateTimeFormatter.ofPattern("yyyy-MM")
 
 fun formatAmount(amount: Int): String {
     return "%,d".format(kotlin.math.abs(amount))

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@ z   <string name="text_quiz_number">%1$d/%2$d</string>">
     <!-- 용돈 일기 페이지 -->
     <string name="text_month_total_consume">%s원 사용 중</string>
     <string name="text_month_most_consume">%d월 달 %s에서 소비를 많이 했어요</string>
+    <string name="text_category_consume">에서 %s원 사용 중</string>
     <string name="text_month_most_consume2">에서 소비를 많이 했어요</string>
     <string name="text_month_no_consume">이번 달에는 소비 내역이 없습니다.</string>
     <string name="text_consuming">소비 중</string>


### PR DESCRIPTION
## 📝작업 내용

> 용돈일기 달력 화면이랑 분석 화면에서 포맷 변수를 빼고 유틸 파일의 상수로 포맷을 진행하였습니다. 카테고리 상세내역 화면 구현했씁니다.

## 작업 상세 내용

- [ ] 용돈일기 달력 화면이랑 분석화면 포맷 변수 없애고 유틸 파일의 상수를 사용
- [ ] 각 리소스 추가
- [ ] 카테고리 상세 내역 화면 구현