### PR TITLE
refactor: 홈, 퀴즈 진입, 학습 화면 리팩토링

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/model/ChatMessage.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/ChatMessage.kt
@@ -1,3 +1,0 @@
-package com.paykidscompose.presentation.model
-
-data class ChatMessage(val text: String, val isFromGpt: Boolean)

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/ChatMessageUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/ChatMessageUIModel.kt
@@ -1,0 +1,6 @@
+package com.paykidscompose.presentation.model
+
+data class ChatMessageUIModel(
+    val text: String,
+    val isFromGpt: Boolean
+): UIModel()

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/QuizClearConfigUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/QuizClearConfigUIModel.kt
@@ -11,17 +11,17 @@ import com.paykidscompose.presentation.ui.theme.Purple2
 import com.paykidscompose.presentation.ui.theme.QuizClearSmallSpacer
 import com.paykidscompose.presentation.ui.theme.QuizClearSpacer
 
-data class QuizClearConfig(
+data class QuizClearConfigUIModel(
     val textRes: Int,
     val bgRes: Int,
     val spacerHeight: Dp,
     val showReviewButton: Boolean,
     val shadowColor: Color,
     val dashedBorderColor: Color
-)
+): UIModel()
 
-fun QuizClearType.toConfig(): QuizClearConfig = when (this) {
-    QuizClearType.ALL_CLEAR -> QuizClearConfig(
+fun QuizClearType.toConfig(): QuizClearConfigUIModel = when (this) {
+    QuizClearType.ALL_CLEAR -> QuizClearConfigUIModel(
         textRes = R.string.text_box_all_clear,
         bgRes = R.drawable.bg_quiz_clear,
         spacerHeight = QuizClearSpacer,
@@ -30,7 +30,7 @@ fun QuizClearType.toConfig(): QuizClearConfig = when (this) {
         dashedBorderColor = Purple2
     )
 
-    QuizClearType.CLEAR_SUCCESS -> QuizClearConfig(
+    QuizClearType.CLEAR_SUCCESS -> QuizClearConfigUIModel(
         textRes = R.string.text_box_first_clear,
         bgRes = R.drawable.bg_quiz_clear,
         spacerHeight = QuizClearSmallSpacer,
@@ -39,7 +39,7 @@ fun QuizClearType.toConfig(): QuizClearConfig = when (this) {
         dashedBorderColor = Purple2
     )
 
-    QuizClearType.CLEAR_FAILED -> QuizClearConfig(
+    QuizClearType.CLEAR_FAILED -> QuizClearConfigUIModel(
         textRes = R.string.text_box_failed,
         bgRes = R.drawable.bg_quiz_fail,
         spacerHeight = QuizClearSmallSpacer,
@@ -48,7 +48,7 @@ fun QuizClearType.toConfig(): QuizClearConfig = when (this) {
         dashedBorderColor = Gray8
     )
 
-    QuizClearType.WRONG_ANSWER_QUIZ_CLEAR -> QuizClearConfig(
+    QuizClearType.WRONG_ANSWER_QUIZ_CLEAR -> QuizClearConfigUIModel(
         textRes = R.string.text_box_incorrect_answer_note_clear,
         bgRes = R.drawable.bg_quiz_clear,
         spacerHeight = QuizClearSpacer,
@@ -57,7 +57,7 @@ fun QuizClearType.toConfig(): QuizClearConfig = when (this) {
         dashedBorderColor = Purple2
     )
 
-    QuizClearType.WRONG_ANSWER_QUIZ_FAILED -> QuizClearConfig(
+    QuizClearType.WRONG_ANSWER_QUIZ_FAILED -> QuizClearConfigUIModel(
         textRes = R.string.text_box_failed,
         bgRes = R.drawable.bg_quiz_fail,
         spacerHeight = QuizClearSpacer,
@@ -66,7 +66,7 @@ fun QuizClearType.toConfig(): QuizClearConfig = when (this) {
         dashedBorderColor = Gray8
     )
 
-    QuizClearType.REVIEW_COMPLETED -> QuizClearConfig(
+    QuizClearType.REVIEW_COMPLETED -> QuizClearConfigUIModel(
         textRes = R.string.text_box_review,
         bgRes = R.drawable.bg_quiz_clear,
         spacerHeight = QuizClearSpacer,

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
@@ -224,16 +224,13 @@ fun HomeScreen(
                         )
                 ) {
                     Text(
-                        text = selectedStageIndex.intValue.let {
-                            stringResource(R.string.text_stage_number, it + 1)
-                        },
+                        text = stringResource(R.string.text_stage_number, selectedStageIndex.intValue + 1),
                         modifier = Modifier.fillMaxWidth(),
                         style = StageCardNumberTextStyle
                     )
                     Spacer(modifier = Modifier.height(StageDescriptionCardTextSpacer))
                     Text(
-                        text = selectedStageIndex.intValue?.let { getStageTitle(it) }
-                            ?: stringResource(R.string.text_stage_title),
+                        text = getStageTitle(selectedStageIndex.intValue),
                         modifier = Modifier.fillMaxWidth(),
                         style = StageCardTitleTextStyle
                     )

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -51,7 +51,7 @@ fun QuizEntryScreen(
     onStudyClick: () -> Unit = {}
 ) {
     var showDialog by remember { mutableStateOf(false) }
-    var stageTitle by remember { mutableStateOf(getStageTitle(stageNumber)) }
+    var stageTitle by remember { mutableStateOf(getStageTitle(stageNumber - 1)) }
 
     Box(
         modifier = Modifier.fillMaxSize()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.model.ChatMessage
+import com.paykidscompose.presentation.model.ChatMessageUIModel
 import com.paykidscompose.presentation.screens.PayKidsScaffold
 import com.paykidscompose.presentation.ui.components.AppTopBar
 import com.paykidscompose.presentation.ui.components.OutlineInputField
@@ -112,10 +112,10 @@ fun Study(
 fun StudyScreen(modifier: Modifier = Modifier) {
     val messages = remember {
         mutableStateListOf(
-            ChatMessage("어린이 여러분 돈이란 무엇일까요?\n돈이 뭐냐면 사고 싶은 걸 살 수 있는 거랍니다", isFromGpt = true),
-            ChatMessage("우와 그렇구나\n돈 없이는 사고 싶은 걸 가질 수 없나요?", isFromGpt = false),
-            ChatMessage("아니요 불가능한 건 없답니다\n바로바로 아무도 모르게 훔치는 방법인데요", isFromGpt = true),
-            ChatMessage("아하~", isFromGpt = false),
+            ChatMessageUIModel("어린이 여러분 돈이란 무엇일까요?\n돈이 뭐냐면 사고 싶은 걸 살 수 있는 거랍니다", isFromGpt = true),
+            ChatMessageUIModel("우와 그렇구나\n돈 없이는 사고 싶은 걸 가질 수 없나요?", isFromGpt = false),
+            ChatMessageUIModel("아니요 불가능한 건 없답니다\n바로바로 아무도 모르게 훔치는 방법인데요", isFromGpt = true),
+            ChatMessageUIModel("아하~", isFromGpt = false),
         )
     }
     val stageNumber = "스테이지 3"
@@ -157,13 +157,13 @@ fun StudyScreen(modifier: Modifier = Modifier) {
 
         ChatInput(text = userInput, onTextChanged = { userInput = it }, onSendClick = {
             if (userInput.isNotBlank()) {
-                messages.add(ChatMessage(userInput, isFromGpt = false))
+                messages.add(ChatMessageUIModel(userInput, isFromGpt = false))
                 userInput = ""
 
                 // TODO: GPT 응답 받는 로직
                 coroutineScope.launch {
                     delay(500)
-                    messages.add(ChatMessage("GPT 응답 예시", isFromGpt = true))
+                    messages.add(ChatMessageUIModel("GPT 응답 예시", isFromGpt = true))
                     listState.animateScrollToItem(messages.size - 1)
                 }
             }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -41,6 +42,7 @@ import com.paykidscompose.presentation.ui.components.AppTopBar
 import com.paykidscompose.presentation.ui.components.OutlineInputField
 import com.paykidscompose.presentation.ui.theme.Black
 import com.paykidscompose.presentation.ui.theme.Blue1
+import com.paykidscompose.presentation.ui.theme.Gray1
 import com.paykidscompose.presentation.ui.theme.Gray5
 import com.paykidscompose.presentation.ui.theme.Gray6
 import com.paykidscompose.presentation.ui.theme.Gray7
@@ -63,6 +65,7 @@ import com.paykidscompose.presentation.ui.theme.StudyChatInputFieldRound
 import com.paykidscompose.presentation.ui.theme.StudyChatInputFieldStartPadding
 import com.paykidscompose.presentation.ui.theme.StudyChatInputRoundTopEnd
 import com.paykidscompose.presentation.ui.theme.StudyChatInputRoundTopStart
+import com.paykidscompose.presentation.ui.theme.StudyChatInputShadowElevation
 import com.paykidscompose.presentation.ui.theme.StudyChatInputTextStyle
 import com.paykidscompose.presentation.ui.theme.StudyChatNicknameTextStyle
 import com.paykidscompose.presentation.ui.theme.StudyChatSendIconSize
@@ -109,7 +112,7 @@ fun Study(
 fun StudyScreen(modifier: Modifier = Modifier) {
     val messages = remember {
         mutableStateListOf(
-            ChatMessage("돈이란 무엇인가요?", isFromGpt = true),
+            ChatMessage("어린이 여러분 돈이란 무엇일까요?\n돈이 뭐냐면 사고 싶은 걸 살 수 있는 거랍니다", isFromGpt = true),
             ChatMessage("우와 그렇구나\n돈 없이는 사고 싶은 걸 가질 수 없나요?", isFromGpt = false),
             ChatMessage("아니요 불가능한 건 없답니다\n바로바로 아무도 모르게 훔치는 방법인데요", isFromGpt = true),
             ChatMessage("아하~", isFromGpt = false),
@@ -223,7 +226,7 @@ fun UserBubble(userNickname: String, text: String) {
     Column(
         modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.End
     ) {
-        Text(text = userNickname, style = StudyChatNicknameTextStyle)
+        Text(text = userNickname, style = StudyChatNicknameTextStyle.copy(color = Gray1))
         Spacer(modifier = Modifier.height(StudyChatBubbleNicknameSpacer))
         Box(
             modifier = Modifier
@@ -258,9 +261,18 @@ fun ChatInput(
     text: String, onTextChanged: (String) -> Unit, onSendClick: () -> Unit
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = StudyChatInputShadowElevation,
+                shape = RoundedCornerShape(
+                    StudyChatInputRoundTopStart, StudyChatInputRoundTopEnd
+                )
+            ),
+        shape = RoundedCornerShape(
             StudyChatInputRoundTopStart, StudyChatInputRoundTopEnd
-        ), colors = CardDefaults.cardColors(containerColor = White4)
+        ),
+        colors = CardDefaults.cardColors(containerColor = White4)
     ) {
         Box(
             modifier = Modifier
@@ -283,7 +295,8 @@ fun ChatInput(
                 backgroundColor = White
             )
             IconButton(
-                onClick = onSendClick, modifier = Modifier.align(Alignment.CenterEnd)
+                onClick = onSendClick,
+                modifier = Modifier.align(Alignment.CenterEnd)
             ) {
                 Image(
                     painter = painterResource(R.drawable.ic_send),

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -115,6 +115,7 @@ val StudyChatUserBubbleRoundBottomStart = 10.dp
 val StudyChatUserBubbleBorderWidth = 1.dp
 val StudyChatBubbleHorizontalPadding = 10.dp
 val StudyChatBubbleVerticalPadding = 8.dp
+val StudyChatInputShadowElevation = 100.dp
 val StudyChatInputRoundTopStart = 10.dp
 val StudyChatInputRoundTopEnd = 10.dp
 val StudyChatInputRoundBottomEnd = 0.dp


### PR DESCRIPTION
## 📝작업 내용

> 홈, 퀴즈 진입, 학습 화면 리팩토링

## 작업 상세 내용

- [x] 퀴즈 진입 시 더미 스테이지 인덱스 문제 해결
- [x] 홈 let 함수 제거
- [x] 학습하기 채팅 영역 그림자 추가, 유저 닉네임 텍스트 컬러 설정

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 