### PR TITLE
feat: 스플래시 액티비티 / refactor: 내비게이션 실행만 되도록 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
     }
     buildFeatures {
         compose = true
+        viewBinding = true
     }
 }
 
@@ -52,6 +53,10 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.material)
+    implementation(libs.androidx.activity)
+    implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,15 +13,20 @@
         android:theme="@style/Theme.PayKidsCompose"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".SplashActivity"
             android:exported="true"
-            android:label="@string/app_name"
-            android:theme="@style/Theme.PayKidsCompose">
+            android:screenOrientation="portrait"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="false"
+            android:theme="@style/Theme.PayKidsCompose">
         </activity>
     </application>
 

--- a/app/src/main/java/com/paykidscompose/app/SplashActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/SplashActivity.kt
@@ -1,0 +1,36 @@
+package com.paykidscompose.app
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import androidx.activity.ComponentActivity
+import com.paykidscompose.app.databinding.ActivitySplashBinding
+
+class SplashActivity : ComponentActivity() {
+
+    private lateinit var binding: ActivitySplashBinding
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivitySplashBinding.inflate(layoutInflater).also{
+            setContentView(it.root)
+        }
+    }
+    override fun onResume() {
+        super.onResume()
+        handler.postDelayed({
+            Log.e(TAG, "초기화 작업 시작!")
+            startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+            finish()
+        }, 1500L)
+    }
+
+    companion object {
+        private const val TAG = "Splash Activity"
+    }
+}

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".SplashActivity"
+    android:background="@color/blue1"
+    android:gravity="center">
+
+    <ImageView
+        android:layout_width="174dp"
+        android:layout_height="174dp"
+        android:src="@drawable/paykids_logo_white"/>
+</LinearLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.PayKidsCompose" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.PayKidsCompose" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ coilCompose = "3.2.0"
 coilSvg = "2.7.0"
 kotlinxSerializationJson = "1.8.1"
 navigationCompose = "2.9.0"
+activity = "1.10.1"
+constraintlayout = "2.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -37,6 +39,8 @@ coil3-coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", versio
 coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coilSvg" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -46,7 +46,15 @@ fun PayKidsApp(
 ) {
     val navController: NavHostController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute: NavigationRoute? = navBackStackEntry?.toRoute<NavigationRoute>()
+    val currentRoute = navBackStackEntry?.destination.let {
+        try {
+            navBackStackEntry?.toRoute<NavigationRoute>()
+        } catch(e: Exception) {
+            Log.e("PayKidsApp", "현재 목적지 경로 에러: $it", e)
+            null
+        }
+    }
+
     Log.d("PayKidsApp", "CurrentRoute: $currentRoute")
 
     var isLogin by remember { mutableStateOf(false) }


### PR DESCRIPTION
진입점을 스플래시 액티비티로 수정
안드로이드12 버전부터 기본 스플래시 화면이 나오는데 커스텀 스플래시만 나오도록 수정

## 📝작업 내용

> 스플래시 액티비티 추가 및 진입점을 스플래시 액티비티로 수정. 그리고 내비게이션 null만 나오는 것을 try catch로 묶어서 실행은 가능하도록 바꿈. 바텀바는 안 나옴 계속해서 에러는 일어나지만 앱은 실행됨

## 작업 상세 내용

- [x] 스플래시 액티비티 추가
- [x] 진입점 스플래시 액티비티로 수정
- [x] 인텐트로 메인액티비티 연결
- [x] 내비게이션 null 처리 추가

### 💬리뷰 요구사항(선택)

> 앱은 실행되도록 바꿨습니다. 바텀바는 나오지 않아요. 현재 루트가 null로 계속 돼서 내일 수정 해야할 거 같습니다.