### PR TITLE
refactor: 퀴즈클리어 화면에서 홈으로 이동했을 때 백스택에 남아서 홈에서 뒤로가기 하면 앱이 종료 안되는 것을 수정.

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -136,7 +136,11 @@ fun PayKidsApp(
                 QuizClearScreen(
                     clearType = clearType,
                     onExitClick = {
-                        navController.navigate(TabNavigationRoute.HomeRoute)
+                        navController.navigate(TabNavigationRoute.HomeRoute) {
+                            popUpTo(navController.graph.findStartDestination().id)
+                            launchSingleTop = true
+                            // 백스택 맨 위에가 홈이라면 기존 화면을 재사용하기 위해서 넣음.
+                        }
                     }
                 )
             }


### PR DESCRIPTION
## 📝작업 내용

> 퀴즈클리어를 갔다가 홈에서 다른 탭 이동을 한 다음 뒤로가기를 하면 퀴즈 관련 화면들까지 뒤로가기가 되는 것을 수정.