### PR TITLE
refactor: 홈, 퀴즈 화면 상위 컴포저블 함수로 분리

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/dummy/DummyQuiz.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/dummy/DummyQuiz.kt
@@ -1,13 +1,25 @@
 package com.paykidscompose.presentation.dummy
 
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.model.QuizUIModel
 import com.paykidscompose.presentation.model.type.QuizType
+
+data class Quiz(
+    val id: Int,
+    val stage: Int,
+    val number: Int,
+    val quizType: QuizType,
+    val question: String,
+    val choices: List<Pair<String, String>>?,
+    val answer: String,
+    val imageUrl: List<Int>?,
+    val totalCount: Int
+)
 
 object DummyQuiz {
     private val dummyQuizzes = listOf(
         // --- Stage 1 ---
-        QuizUIModel(
+        Quiz(
+            id = 1,
             stage = 1,
             number = 1,
             quizType = QuizType.TEXT_CHOICE,
@@ -22,7 +34,8 @@ object DummyQuiz {
             imageUrl = null,
             totalCount = 6
         ),
-        QuizUIModel(
+        Quiz(
+            id = 2,
             stage = 1,
             number = 2,
             quizType = QuizType.SHORT_ANSWER,
@@ -32,7 +45,8 @@ object DummyQuiz {
             imageUrl = null,
             totalCount = 6
         ),
-        QuizUIModel(
+        Quiz(
+            id = 3,
             stage = 1,
             number = 3,
             quizType = QuizType.IMAGE,
@@ -52,7 +66,8 @@ object DummyQuiz {
             ),
             totalCount = 6
         ),
-        QuizUIModel(
+        Quiz(
+            id = 4,
             stage = 1,
             number = 4,
             quizType = QuizType.TEXT_CHOICE_IMAGE,
@@ -67,7 +82,8 @@ object DummyQuiz {
             imageUrl = listOf(R.drawable.img_quiz_item_default),
             totalCount = 6
         ),
-        QuizUIModel(
+        Quiz(
+            id = 5,
             stage = 1,
             number = 5,
             quizType = QuizType.SHORT_ANSWER_IMAGE,
@@ -77,7 +93,8 @@ object DummyQuiz {
             imageUrl = listOf(R.drawable.img_king_sejong),
             totalCount = 6
         ),
-        QuizUIModel(
+        Quiz(
+            id = 6,
             stage = 1,
             number = 6,
             quizType = QuizType.TEXT_CHOICE,
@@ -94,7 +111,8 @@ object DummyQuiz {
         ),
 
         // --- Stage 2 ---
-        QuizUIModel(
+        Quiz(
+            id = 7,
             stage = 2,
             number = 1,
             quizType = QuizType.TEXT_CHOICE,
@@ -108,7 +126,8 @@ object DummyQuiz {
             imageUrl = null,
             totalCount = 5
         ),
-        QuizUIModel(
+        Quiz(
+            id = 8,
             stage = 2,
             number = 2,
             quizType = QuizType.SHORT_ANSWER,
@@ -118,7 +137,8 @@ object DummyQuiz {
             imageUrl = null,
             totalCount = 5
         ),
-        QuizUIModel(
+        Quiz(
+            id = 9,
             stage = 2,
             number = 3,
             quizType = QuizType.TEXT_CHOICE_IMAGE,
@@ -138,7 +158,8 @@ object DummyQuiz {
             ),
             totalCount = 5
         ),
-        QuizUIModel(
+        Quiz(
+            id = 10,
             stage = 2,
             number = 4,
             quizType = QuizType.SHORT_ANSWER,
@@ -148,7 +169,8 @@ object DummyQuiz {
             imageUrl = null,
             totalCount = 5
         ),
-        QuizUIModel(
+        Quiz(
+            id = 11,
             stage = 2,
             number = 5,
             quizType = QuizType.TEXT_CHOICE,
@@ -165,15 +187,15 @@ object DummyQuiz {
         ),
     )
 
-    fun getQuiz(stage: Int, number: Int): QuizUIModel? {
+    fun getQuiz(stage: Int, number: Int): Quiz? {
         return dummyQuizzes.firstOrNull { it.stage == stage && it.number == number }
     }
 
-    fun getQuizzes(stage: Int): List<QuizUIModel> {
+    fun getQuizzes(stage: Int): List<Quiz> {
         return dummyQuizzes.filter { it.stage == stage }.sortedBy { it.number }
     }
 
-    fun getWrongAnswerNoteQuizzes(stage: Int, wrongAnswerQuizNumbers: List<Int>): List<QuizUIModel> {
+    fun getWrongAnswerNoteQuizzes(stage: Int, wrongAnswerQuizNumbers: List<Int>): List<Quiz> {
         return wrongAnswerQuizNumbers.mapNotNull { number ->
             getQuiz(stage, number)
         }

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -30,9 +30,9 @@ import com.paykidscompose.presentation.screens.login.nickname.NicknameScreen
 import com.paykidscompose.presentation.screens.mypage.MyPageScreen
 import com.paykidscompose.presentation.screens.mypage.info.MyInfoScreen
 import com.paykidscompose.presentation.screens.mypage.terms.TermsPolicyScreen
+import com.paykidscompose.presentation.screens.quiz.Quiz
 import com.paykidscompose.presentation.screens.quiz.QuizClearScreen
 import com.paykidscompose.presentation.screens.quiz.QuizEntryScreen
-import com.paykidscompose.presentation.screens.quiz.QuizScreen
 import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.study.Study
 import com.paykidscompose.presentation.ui.components.AppBottomBar
@@ -122,7 +122,7 @@ fun PayKidsApp(
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.QuizRoute>()
                 val stageNumber = targetRoute.stageNumber
 
-                QuizScreen(
+                Quiz(
                     stageNumber = stageNumber,
                     quizViewModel = quizViewModel,
                     onBackClick = {

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -32,7 +32,7 @@ import com.paykidscompose.presentation.screens.mypage.info.MyInfoScreen
 import com.paykidscompose.presentation.screens.mypage.terms.TermsPolicyScreen
 import com.paykidscompose.presentation.screens.quiz.Quiz
 import com.paykidscompose.presentation.screens.quiz.QuizClearScreen
-import com.paykidscompose.presentation.screens.quiz.QuizEntryScreen
+import com.paykidscompose.presentation.screens.quiz.QuizEntry
 import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.study.Study
 import com.paykidscompose.presentation.ui.components.AppBottomBar
@@ -106,7 +106,7 @@ fun PayKidsApp(
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.QuizEntryRoute>()
                 val stageNumber = targetRoute.stageNumber
 
-                QuizEntryScreen(
+                QuizEntry(
                     stageNumber = stageNumber,
                     quizViewModel = quizViewModel,
                     onQuiz = {

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -24,7 +24,7 @@ import com.paykidscompose.presentation.screens.PayKidsScaffold
 import com.paykidscompose.presentation.screens.allowance.AllowanceDiaryScreen
 import com.paykidscompose.presentation.screens.allowance.analysis.ExpenseAnalysis
 import com.paykidscompose.presentation.screens.allowance.detail.CategoryDetail
-import com.paykidscompose.presentation.screens.home.HomeScreen
+import com.paykidscompose.presentation.screens.home.Home
 import com.paykidscompose.presentation.screens.login.LoginScreen
 import com.paykidscompose.presentation.screens.login.nickname.NicknameScreen
 import com.paykidscompose.presentation.screens.mypage.MyPageScreen
@@ -95,7 +95,7 @@ fun PayKidsApp(
             }
 
             composable<TabNavigationRoute.HomeRoute> {
-                HomeScreen { stageNumber ->
+                Home { stageNumber ->
                     navController.navigate(
                         QuizNavigationRoute.QuizEntryRoute(stageNumber)
                     )

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -33,7 +33,6 @@ import com.paykidscompose.presentation.screens.mypage.terms.TermsPolicyScreen
 import com.paykidscompose.presentation.screens.quiz.Quiz
 import com.paykidscompose.presentation.screens.quiz.QuizClear
 import com.paykidscompose.presentation.screens.quiz.QuizEntry
-import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.study.Study
 import com.paykidscompose.presentation.ui.components.AppBottomBar
 
@@ -50,8 +49,6 @@ fun PayKidsApp(
     Log.d("PayKidsApp", "CurrentRoute: $currentRoute")
 
     var isLogin by remember { mutableStateOf(false) }
-
-    val quizViewModel = remember { QuizViewModel() }
 
     PayKidsScaffold(
         bottomBar = {
@@ -108,7 +105,6 @@ fun PayKidsApp(
 
                 QuizEntry(
                     stageNumber = stageNumber,
-                    quizViewModel = quizViewModel,
                     onQuiz = {
                         navController.navigate(QuizNavigationRoute.QuizRoute(stageNumber))
                     },
@@ -124,7 +120,6 @@ fun PayKidsApp(
 
                 Quiz(
                     stageNumber = stageNumber,
-                    quizViewModel = quizViewModel,
                     onBackClick = {
                         navController.popBackStack()
                     },

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -31,7 +31,7 @@ import com.paykidscompose.presentation.screens.mypage.MyPageScreen
 import com.paykidscompose.presentation.screens.mypage.info.MyInfoScreen
 import com.paykidscompose.presentation.screens.mypage.terms.TermsPolicyScreen
 import com.paykidscompose.presentation.screens.quiz.Quiz
-import com.paykidscompose.presentation.screens.quiz.QuizClearScreen
+import com.paykidscompose.presentation.screens.quiz.QuizClear
 import com.paykidscompose.presentation.screens.quiz.QuizEntry
 import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.study.Study
@@ -138,7 +138,7 @@ fun PayKidsApp(
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.QuizClearRoute>()
                 val clearType = targetRoute.clear
 
-                QuizClearScreen(
+                QuizClear(
                     clearType = clearType,
                     onExitClick = {
                         navController.navigate(TabNavigationRoute.HomeRoute)

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
@@ -45,19 +45,15 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.dummy.getStageTitle
-import com.paykidscompose.presentation.navigation.bottom.BottomBarItem
-import com.paykidscompose.presentation.screens.PayKidsScaffold
-import com.paykidscompose.presentation.ui.components.AppBottomBar
 import com.paykidscompose.presentation.ui.components.ImageTooltip
 import com.paykidscompose.presentation.ui.theme.Blue1
 import com.paykidscompose.presentation.ui.theme.CardShadowElevation
+import com.paykidscompose.presentation.ui.theme.PayKidsComposeTheme
 import com.paykidscompose.presentation.ui.theme.StageCardNumberTextStyle
 import com.paykidscompose.presentation.ui.theme.StageCardTitleTextStyle
 import com.paykidscompose.presentation.ui.theme.StageCircleBorderWidth
@@ -89,15 +85,30 @@ val stageImageSet = listOf(
 )
 
 @Composable
+fun Home(
+    onStageNumber: (Int) -> Unit = {}
+) {
+    val selectedStageIndex = remember { mutableIntStateOf(6) } // 마지막 클리어 스테이지
+    val tooltipOffset = remember { mutableStateOf<Offset?>(null) }
+
+    HomeScreen(
+        selectedStageIndex = selectedStageIndex.intValue,
+        onStageSelected = { selectedStageIndex.intValue = it },
+        tooltipOffset = tooltipOffset.value,
+        onTooltipOffsetChange = { tooltipOffset.value = it },
+        onStageNumber = onStageNumber
+    )
+}
+
+@Composable
 fun HomeScreen(
+    selectedStageIndex: Int,
+    onStageSelected: (Int) -> Unit,
+    tooltipOffset: Offset?,
+    onTooltipOffsetChange: (Offset?) -> Unit,
     onStageNumber: (Int) -> Unit = {}
 ) {
     val scrollState = rememberLazyListState()
-
-    var clickedStageNumber by remember {
-        mutableIntStateOf(0)
-    }
-
     val density = LocalDensity.current
     val itemHeightDp = StageCircleSize + StageVerticalSpace
     val itemHeightPx = with(density) { itemHeightDp.toPx() }
@@ -109,160 +120,159 @@ fun HomeScreen(
             with(density) { -(totalOffsetPx * 0.6f).toDp() }
         }
     }
+
     val context = LocalContext.current
 
-    val tooltipOffset = remember { mutableStateOf<Offset?>(null) }
-
-    val lastClearedStageIndex = 6 // 클리어 스테이지 인덱스
-    val selectedStageIndex = remember { mutableIntStateOf(lastClearedStageIndex) }
-
     Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(R.drawable.bg_home_2)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            filterQuality = FilterQuality.High,
+            contentScale = ContentScale.FillWidth,
+            clipToBounds = false,
+            alignment = Alignment.TopStart,
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
+                .offset(y = backgroundOffset)
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize(),
+            state = scrollState,
+            verticalArrangement = Arrangement.spacedBy(StageVerticalSpace),
+            contentPadding = PaddingValues(horizontal = StageHorizontalPadding)
         ) {
-            AsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(R.drawable.bg_home_2)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = null,
-                filterQuality = FilterQuality.High,
-                contentScale = ContentScale.FillWidth,
-                clipToBounds = false,
-                alignment = Alignment.TopStart,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .offset(y = backgroundOffset)
-            )
-
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize(),
-                state = scrollState,
-                verticalArrangement = Arrangement.spacedBy(StageVerticalSpace),
-                contentPadding = PaddingValues(horizontal = StageHorizontalPadding)
-            ) {
-                items(totalStageCount) { index ->
-                    if (index == 0) {
-                        Spacer(modifier = Modifier.height(StageTopPadding))
-                    }
-
-                    val (imageRes, borderColor) = getStageVisuals(
-                        index,
-                        unlockedStageCount,
-                        stageImageSet
-                    )
-                    val itemOffset = remember { mutableStateOf(Offset(0f, 0f)) }
-
-                    Box(
-                        modifier = Modifier
-                            .size(StageCircleSize)
-                            .background(color = White, shape = CircleShape)
-                            .border(
-                                width = StageCircleBorderWidth,
-                                color = borderColor,
-                                shape = CircleShape
-                            )
-                            .onGloballyPositioned { coordinates ->
-                                itemOffset.value = coordinates.positionInWindow()
-                            }
-                            .clickable(
-                                indication = null,
-                                interactionSource = remember { MutableInteractionSource() }
-                            ) {
-                                selectedStageIndex.intValue = index
-                                tooltipOffset.value = Offset(itemOffset.value.x, itemOffset.value.y)
-
-                                if (index < unlockedStageCount) {
-                                    onStageNumber(index + 1)
-                                } else {
-
-                                }
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Image(
-                            painter = painterResource(id = imageRes),
-                            contentDescription = null, // ripple 제거
-                            modifier = Modifier.size(StageIconSize)
-                        )
-                    }
+            items(totalStageCount) { index ->
+                if (index == 0) {
+                    Spacer(modifier = Modifier.height(StageTopPadding))
                 }
-            }
 
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .statusBarsPadding()
-                    .padding(
-                        horizontal = StageDescriptionCardHorizontalPadding,
-                        vertical = StageDescriptionCardVerticalPadding
-                    )
-                    .height(StageDescriptionCardHeight)
-                    .shadow(
-                        elevation = CardShadowElevation,
-                        shape = RoundedCornerShape(StageDescriptionCardRound),
-                        ambientColor = Blue1,
-                        spotColor = Blue1
-                    ),
-                shape = RoundedCornerShape(StageDescriptionCardRound),
-                colors = CardDefaults.cardColors(
-                    containerColor = White
+                val (imageRes, borderColor) = getStageVisuals(
+                    index,
+                    unlockedStageCount,
+                    stageImageSet
                 )
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(
-                            horizontal = StageDescriptionCardTextHorizontalPadding,
-                            vertical = StageDescriptionCardTextVerticalPadding
-                        )
-                ) {
-                    Text(
-                        text = stringResource(R.string.text_stage_number, selectedStageIndex.intValue + 1),
-                        modifier = Modifier.fillMaxWidth(),
-                        style = StageCardNumberTextStyle
-                    )
-                    Spacer(modifier = Modifier.height(StageDescriptionCardTextSpacer))
-                    Text(
-                        text = getStageTitle(selectedStageIndex.intValue),
-                        modifier = Modifier.fillMaxWidth(),
-                        style = StageCardTitleTextStyle
-                    )
-                }
-            }
+                val itemOffset = remember { mutableStateOf(Offset(0f, 0f)) }
 
-            // 화면을 클릭하면 툴팁 닫힘
-            if (tooltipOffset.value != null) {
                 Box(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .size(StageCircleSize)
+                        .background(color = White, shape = CircleShape)
+                        .border(
+                            width = StageCircleBorderWidth,
+                            color = borderColor,
+                            shape = CircleShape
+                        )
+                        .onGloballyPositioned { coordinates ->
+                            itemOffset.value = coordinates.positionInWindow()
+                        }
                         .clickable(
-                            onClick = {
-                                tooltipOffset.value = null
-                            },
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() }
-                        )
-                )
-            }
+                        ) {
+                            onStageSelected(index)
+                            onTooltipOffsetChange(itemOffset.value)
 
-            // 툴팁 표시
-            tooltipOffset.value?.let { offset ->
-                ImageTooltip(
-                    tooltipText = stringResource(R.string.text_tooltip_start),
-                    modifier = Modifier
-                        .clickable {
-                            tooltipOffset.value = null
-                        }
-                        .offset {
-                            IntOffset(
-                                offset.x.toInt() - StageTooltipOffsetX,
-                                offset.y.toInt() - StageTooltipOffsetY
-                            )
-                        }
+                            if (index < unlockedStageCount) {
+                                onStageNumber(index + 1)
+                            } else {
+
+                            }
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        painter = painterResource(id = imageRes),
+                        contentDescription = null, // ripple 제거
+                        modifier = Modifier.size(StageIconSize)
+                    )
+                }
+            }
+        }
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(
+                    horizontal = StageDescriptionCardHorizontalPadding,
+                    vertical = StageDescriptionCardVerticalPadding
+                )
+                .height(StageDescriptionCardHeight)
+                .shadow(
+                    elevation = CardShadowElevation,
+                    shape = RoundedCornerShape(StageDescriptionCardRound),
+                    ambientColor = Blue1,
+                    spotColor = Blue1
+                ),
+            shape = RoundedCornerShape(StageDescriptionCardRound),
+            colors = CardDefaults.cardColors(
+                containerColor = White
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        horizontal = StageDescriptionCardTextHorizontalPadding,
+                        vertical = StageDescriptionCardTextVerticalPadding
+                    )
+            ) {
+                Text(
+                    text = stringResource(
+                        R.string.text_stage_number,
+                        selectedStageIndex + 1
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                    style = StageCardNumberTextStyle
+                )
+                Spacer(modifier = Modifier.height(StageDescriptionCardTextSpacer))
+                Text(
+                    text = getStageTitle(selectedStageIndex),
+                    modifier = Modifier.fillMaxWidth(),
+                    style = StageCardTitleTextStyle
                 )
             }
+        }
+
+        // 화면을 클릭하면 툴팁 닫힘
+        if (tooltipOffset != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(
+                        onClick = {
+                            onTooltipOffsetChange(null)
+                        },
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    )
+            )
+        }
+
+        // 툴팁 표시
+        tooltipOffset?.let { offset ->
+            ImageTooltip(
+                tooltipText = stringResource(R.string.text_tooltip_start),
+                modifier = Modifier
+                    .clickable {
+                        onTooltipOffsetChange(null)
+                    }
+                    .offset {
+                        IntOffset(
+                            offset.x.toInt() - StageTooltipOffsetX,
+                            offset.y.toInt() - StageTooltipOffsetY
+                        )
+                    }
+            )
+        }
 
     }
 }
@@ -270,6 +280,8 @@ fun HomeScreen(
 
 @Preview
 @Composable
-fun HomeScreenPreview(){
-    HomeScreen()
+fun HomeScreenPreview() {
+    PayKidsComposeTheme {
+        Home()
+    }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizClearScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizClearScreen.kt
@@ -7,16 +7,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import coil3.compose.AsyncImage
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.model.type.QuizClearType
+import com.paykidscompose.presentation.model.QuizClearConfigUIModel
 import com.paykidscompose.presentation.model.toConfig
+import com.paykidscompose.presentation.model.type.QuizClearType
 import com.paykidscompose.presentation.ui.components.DashedCard
 import com.paykidscompose.presentation.ui.components.DecisionButton
 import com.paykidscompose.presentation.ui.theme.Black
@@ -29,16 +28,22 @@ import com.paykidscompose.presentation.ui.theme.QuizClearScreenColumnTopPadding
 import com.paykidscompose.presentation.ui.theme.StartAndEndPadding
 import com.paykidscompose.presentation.ui.theme.White
 
-
 @Composable
-fun QuizClearScreen(
+fun QuizClear(
     clearType: QuizClearType,
     onExitClick: () -> Unit = {}
 ) {
-    val isClear = remember { mutableStateOf(QuizClearType.ALL_CLEAR) }
+    QuizClearScreen(
+        config = clearType.toConfig(),
+        onExitClick = onExitClick
+    )
+}
 
-    val config = clearType.toConfig()
-
+@Composable
+fun QuizClearScreen(
+    config: QuizClearConfigUIModel,
+    onExitClick: () -> Unit = {}
+) {
     Box(modifier = Modifier.fillMaxSize()) {
         AsyncImage(
             model = config.bgRes,
@@ -86,6 +91,6 @@ fun QuizClearScreen(
 @Composable
 fun QuizClearScreenPreview() {
     PayKidsComposeTheme {
-        QuizClearScreen(QuizClearType.ALL_CLEAR)
+        QuizClear(QuizClearType.ALL_CLEAR)
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -31,6 +31,7 @@ import com.paykidscompose.presentation.ui.theme.Blue1
 import com.paykidscompose.presentation.ui.theme.DeterminationButtonTextTopAndBottom2
 import com.paykidscompose.presentation.ui.theme.DeterminationTextStyle2
 import com.paykidscompose.presentation.ui.theme.Gray5
+import com.paykidscompose.presentation.ui.theme.PayKidsComposeTheme
 import com.paykidscompose.presentation.ui.theme.QuizEntryButtonSpacer
 import com.paykidscompose.presentation.ui.theme.QuizEntryScreenBottomPadding
 import com.paykidscompose.presentation.ui.theme.QuizEntryScreenSpacer1
@@ -45,14 +46,35 @@ import com.paykidscompose.presentation.ui.theme.StartAndEndPadding
 import com.paykidscompose.presentation.ui.theme.White
 
 @Composable
-fun QuizEntryScreen(
+fun QuizEntry(
     stageNumber: Int,
     quizViewModel: QuizViewModel,
+    onShowDialogChange: (Boolean) -> Unit = {},
     onQuiz: (Int) -> Unit = {},
     onStudyClick: () -> Unit = {}
 ) {
     var showDialog by remember { mutableStateOf(false) }
-    var stageTitle by remember { mutableStateOf(getStageTitle(stageNumber - 1)) }
+
+    QuizEntryScreen(
+        stageNumber = stageNumber,
+        quizViewModel = quizViewModel,
+        showDialog = showDialog,
+        onShowDialogChange = onShowDialogChange,
+        onQuiz = onQuiz,
+        onStudyClick = onStudyClick
+    )
+}
+
+@Composable
+fun QuizEntryScreen(
+    stageNumber: Int,
+    quizViewModel: QuizViewModel,
+    showDialog: Boolean,
+    onShowDialogChange: (Boolean) -> Unit,
+    onQuiz: (Int) -> Unit = {},
+    onStudyClick: () -> Unit = {}
+) {
+    val stageTitle = getStageTitle(stageNumber - 1)
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -61,8 +83,8 @@ fun QuizEntryScreen(
             PopupDialog(
                 title = stringResource(R.string.dialog_incorrect_nothing),
                 popupType = PopupType.INCORRECT_ANSWER_NOTE_ERROR,
-                onCancelClick = { showDialog = false },
-                onConfirmClick = { showDialog = false },
+                onCancelClick = { onShowDialogChange(false) },
+                onConfirmClick = { onShowDialogChange(false) },
                 description = ""
             )
         }
@@ -125,7 +147,7 @@ fun QuizEntryScreen(
             DecisionButton( // 오답노트 풀기
                 text = stringResource(R.string.text_btn_review),
                 onClick = {
-                    showDialog = true
+                    onShowDialogChange(true)
                 },
                 backgroundColor = White,
                 contentColor = Blue1,
@@ -140,5 +162,7 @@ fun QuizEntryScreen(
 @Preview
 @Composable
 fun QuizEntryScreenPreview(){
-    QuizEntryScreen(2, remember { QuizViewModel() })
+    PayKidsComposeTheme {
+        QuizEntry(2, remember { QuizViewModel() })
+    }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -48,7 +48,6 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun QuizEntry(
     stageNumber: Int,
-    quizViewModel: QuizViewModel,
     onShowDialogChange: (Boolean) -> Unit = {},
     onQuiz: (Int) -> Unit = {},
     onStudyClick: () -> Unit = {}
@@ -57,7 +56,6 @@ fun QuizEntry(
 
     QuizEntryScreen(
         stageNumber = stageNumber,
-        quizViewModel = quizViewModel,
         showDialog = showDialog,
         onShowDialogChange = onShowDialogChange,
         onQuiz = onQuiz,
@@ -68,7 +66,6 @@ fun QuizEntry(
 @Composable
 fun QuizEntryScreen(
     stageNumber: Int,
-    quizViewModel: QuizViewModel,
     showDialog: Boolean,
     onShowDialogChange: (Boolean) -> Unit,
     onQuiz: (Int) -> Unit = {},
@@ -135,7 +132,6 @@ fun QuizEntryScreen(
             DecisionButton( // 퀴즈 풀기
                 text = stringResource(R.string.text_btn_quiz),
                 onClick = {
-                    quizViewModel.loadQuiz(stageNumber)
                     onQuiz(stageNumber)
                 },
                 backgroundColor = Blue1,
@@ -163,6 +159,6 @@ fun QuizEntryScreen(
 @Composable
 fun QuizEntryScreenPreview(){
     PayKidsComposeTheme {
-        QuizEntry(2, remember { QuizViewModel() })
+        QuizEntry(2)
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.type.QuizClearType
@@ -49,7 +50,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun Quiz(
     stageNumber: Int,
-    quizViewModel: QuizViewModel,
+    quizViewModel: QuizViewModel = viewModel(),
     onBackClick: () -> Unit,
     onConfirmClick: (QuizClearType) -> Unit
 ) {
@@ -57,6 +58,10 @@ fun Quiz(
     var selectedIndex by remember { mutableStateOf<Int?>(null) }
     var isCorrect by remember { mutableStateOf(QuizResultType.DEFAULT) }
     var userInput by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        quizViewModel.loadQuiz(stageNumber)
+    }
 
     QuizScreen(
         stageNumber = stageNumber,

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -47,13 +47,53 @@ import com.paykidscompose.presentation.ui.theme.TextChoiceQuizImageRound
 import kotlinx.coroutines.delay
 
 @Composable
+fun Quiz(
+    stageNumber: Int,
+    quizViewModel: QuizViewModel,
+    onBackClick: () -> Unit,
+    onConfirmClick: (QuizClearType) -> Unit
+) {
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedIndex by remember { mutableStateOf<Int?>(null) }
+    var isCorrect by remember { mutableStateOf(QuizResultType.DEFAULT) }
+    var userInput by remember { mutableStateOf("") }
+
+    QuizScreen(
+        stageNumber = stageNumber,
+        quizViewModel = quizViewModel,
+        showDialog = showDialog,
+        onShowDialogChange = { showDialog = it },
+        selectedIndex = selectedIndex,
+        onSelectedIndexChange = { selectedIndex = it },
+        isCorrect = isCorrect,
+        onCorrectChange = { isCorrect = it },
+        userInput = userInput,
+        onUserInputChange = { userInput = it },
+        onBackClick = onBackClick,
+        onConfirmClick = onConfirmClick,
+        onChoiceClick = { selectedIndex = it },
+        onConfirmAnswer = { isCorrectAnswer ->
+            isCorrect = if (isCorrectAnswer) QuizResultType.CORRECT else QuizResultType.WRONG
+        }
+    )
+}
+
+@Composable
 fun QuizScreen(
     stageNumber: Int = 1,
     quizViewModel: QuizViewModel,
-    onBackClick: () -> Unit = {},
-    onConfirmClick: (QuizClearType) -> Unit = {},
-    onChoiceClick: (Int) -> Unit = {},
-    onConfirmAnswer: (Boolean) -> Unit = {}
+    showDialog: Boolean,
+    onShowDialogChange: (Boolean) -> Unit,
+    selectedIndex: Int?,
+    onSelectedIndexChange: (Int?) -> Unit,
+    isCorrect: QuizResultType,
+    onCorrectChange: (QuizResultType) -> Unit,
+    userInput: String,
+    onUserInputChange: (String) -> Unit,
+    onBackClick: () -> Unit,
+    onConfirmClick: (QuizClearType) -> Unit,
+    onChoiceClick: (Int) -> Unit,
+    onConfirmAnswer: (Boolean) -> Unit
 ) {
     val currentQuiz = quizViewModel.currentQuiz
     if (currentQuiz == null) {
@@ -67,13 +107,8 @@ fun QuizScreen(
     val totalCount = currentQuiz.totalCount
     val quizNumber = quizViewModel.currentIndex + 1
 
-    var showDialog by remember { mutableStateOf(false) }
-    var selectedIndex by remember { mutableStateOf<Int?>(null) }
-    var isCorrect by remember { mutableStateOf(QuizResultType.DEFAULT) }
-    var userInput by remember { mutableStateOf("") }
-
     BackHandler(enabled = true) {
-        showDialog = true
+        onShowDialogChange(true)
     }
 
     if (showDialog) {
@@ -81,10 +116,10 @@ fun QuizScreen(
             title = stringResource(R.string.dialog_check_exit),
             popupType = PopupType.QUIZ_EXIT,
             onCancelClick = {
-                showDialog = false
+                onShowDialogChange(false)
             },
             onConfirmClick = {
-                showDialog = false
+                onShowDialogChange(false)
                 onBackClick()
             },
             description = ""
@@ -98,9 +133,9 @@ fun QuizScreen(
                 onConfirmClick(QuizClearType.ALL_CLEAR)
             } else {
                 quizViewModel.moveToNext()
-                selectedIndex = null
-                isCorrect = QuizResultType.DEFAULT
-                userInput = ""
+                onSelectedIndexChange(null)
+                onCorrectChange(QuizResultType.DEFAULT)
+                onUserInputChange("")
             }
         }
     }
@@ -111,7 +146,7 @@ fun QuizScreen(
         QuizTopBar(
             quizNumber = quizNumber,
             totalQuizCount = totalCount,
-            onBackClick = { showDialog = true }
+            onBackClick = { onShowDialogChange(true) }
         )
         Box(
             modifier = Modifier.fillMaxSize()
@@ -167,9 +202,9 @@ fun QuizScreen(
                             selectedIndex = selectedIndex,
                             isCorrect = isCorrect,
                             onChoiceClick = { index ->
-                                selectedIndex = index
-                                isCorrect =
-                                    if (index == (currentQuiz.answer[0] - 'A')) QuizResultType.CORRECT else QuizResultType.WRONG
+                                onSelectedIndexChange(index)
+                                val isRight = index == (currentQuiz.answer[0] - 'A')
+                                onCorrectChange(if (isRight) QuizResultType.CORRECT else QuizResultType.WRONG)
                                 onChoiceClick(index)
                             }
                         )
@@ -183,9 +218,9 @@ fun QuizScreen(
                             selectedIndex = selectedIndex,
                             isCorrect = isCorrect,
                             onChoiceClick = { index ->
-                                selectedIndex = index
-                                isCorrect =
-                                    if (index == (currentQuiz.answer[0] - 'A')) QuizResultType.CORRECT else QuizResultType.WRONG
+                                onSelectedIndexChange(index)
+                                val isRight = index == (currentQuiz.answer[0] - 'A')
+                                onCorrectChange(if (isRight) QuizResultType.CORRECT else QuizResultType.WRONG)
                                 onChoiceClick(index)
                             }
                         )
@@ -232,9 +267,9 @@ fun QuizScreen(
                                 selectedIndex = selectedIndex,
                                 isCorrect = isCorrect,
                                 onChoiceClick = { index ->
-                                    selectedIndex = index
-                                    isCorrect =
-                                        if (index == (currentQuiz.answer[0] - 'A')) QuizResultType.CORRECT else QuizResultType.WRONG
+                                    onSelectedIndexChange(index)
+                                    val isRight = index == (currentQuiz.answer[0] - 'A')
+                                    onCorrectChange(if (isRight) QuizResultType.CORRECT else QuizResultType.WRONG)
                                     onChoiceClick(index)
                                 }
                             )
@@ -245,10 +280,11 @@ fun QuizScreen(
                             quizType = currentQuiz.quizType,
                             userInput = userInput,
                             answer = currentQuiz.answer,
-                            onUserInputChange = { userInput = it },
+                            onUserInputChange = onUserInputChange,
                             onConfirmAnswer = { isCorrectAnswer ->
-                                isCorrect =
+                                onCorrectChange(
                                     if (isCorrectAnswer) QuizResultType.CORRECT else QuizResultType.WRONG
+                                )
                                 onConfirmAnswer(isCorrectAnswer)
                                 //onConfirmClick(QuizClearType.ALL_CLEAR)
                             }
@@ -292,10 +328,11 @@ fun QuizScreen(
                                 quizType = currentQuiz.quizType,
                                 userInput = userInput,
                                 answer = currentQuiz.answer,
-                                onUserInputChange = { userInput = it },
+                                onUserInputChange = onUserInputChange,
                                 onConfirmAnswer = { isCorrectAnswer ->
-                                    isCorrect =
+                                    onCorrectChange(
                                         if (isCorrectAnswer) QuizResultType.CORRECT else QuizResultType.WRONG
+                                    )
                                     onConfirmAnswer(isCorrectAnswer)
                                 }
                             )

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizViewModel.kt
@@ -5,30 +5,44 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.paykidscompose.presentation.dummy.DummyQuiz
 import com.paykidscompose.presentation.model.QuizUIModel
+import kotlinx.coroutines.launch
 
 class QuizViewModel : ViewModel() {
     private val _quizzes = mutableStateListOf<QuizUIModel>()
-    val quizzes: List<QuizUIModel> = _quizzes
 
     var currentIndex by mutableStateOf(0)
         private set
 
-    var currentQuiz by mutableStateOf<QuizUIModel?>(null)
+    var currentQuiz by mutableStateOf(_quizzes.firstOrNull())
         private set
 
     fun loadQuiz(stageNumber: Int) {
-        _quizzes.clear()
-        _quizzes.addAll(DummyQuiz.getQuizzes(stageNumber))
-        currentIndex = 0
-        currentQuiz = _quizzes.getOrNull(currentIndex)
+        viewModelScope.launch {
+            val quizzes = DummyQuiz.getQuizzes(stageNumber).map { quiz ->
+                QuizUIModel(
+                    quiz.stage,
+                    quiz.number,
+                    quiz.quizType,
+                    quiz.question,
+                    quiz.choices,
+                    quiz.answer,
+                    quiz.imageUrl,
+                    quiz.totalCount
+                )
+            }
+            _quizzes.addAll(quizzes)
+            currentIndex = 0
+            currentQuiz = _quizzes[currentIndex]
+        }
     }
 
     fun moveToNext() {
         if (currentIndex < _quizzes.size - 1) {
             currentIndex++
-            currentQuiz = _quizzes.getOrNull(currentIndex)
+            currentQuiz = _quizzes[currentIndex]
         }
     }
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
@@ -330,9 +330,8 @@ fun UserBubblePreview() {
 
 @Preview
 @Composable
-fun StudyPreview() {
+fun StudyScreenPreview() {
     PayKidsComposeTheme {
-        Study(
-        )
+        Study()
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 홈, 퀴즈 화면 상위 컴포저블 함수로 분리

## 작업 상세 내용

- [x] HomeScreen 상위에 Home 컴포저블 함수로 분리
- [x] QuizScreen 상위에 Quiz 컴포저블 함수로 분리
- [x] QuizEntryScreen 상위에 QuizEntry 컴포저블 함수로 분리
- [x] QuizClearScreen 상위에 QuizClear 컴포저블 함수로 분리
- [x] StudyScreenPreview 함수 네이밍 수정
- [x] 함수 분리에 따른 PayKidsApp 파일 수정

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요