### PR TITLE
refactor: 용돈일기 분석 화면 수정

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/model/ExpenseAnalysisUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/ExpenseAnalysisUIModel.kt
@@ -1,0 +1,23 @@
+package com.paykidscompose.presentation.model
+
+import androidx.compose.ui.graphics.Color
+import com.paykidscompose.presentation.base.UIState
+import com.paykidscompose.presentation.model.type.AllowanceType
+import java.time.LocalDate
+
+
+data class AnalysisUIModel(
+    val name: String,
+    val amount: Int,
+    val percent: Float,
+    val color: Color
+)
+
+data class ExpenseAnalysisUiState(
+    override val isLoading: Boolean = false,
+    override val error: String? = null,
+    val stats: List<AnalysisUIModel> = emptyList(),
+    val showInputDialog: Boolean = false,
+    val selectedType: AllowanceType = AllowanceType.EXPENSE,
+    val currentMonth: LocalDate = LocalDate.now()
+): UIState()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/ExpenseAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/ExpenseAnalysisScreen.kt
@@ -59,6 +59,25 @@ import com.paykidscompose.presentation.ui.theme.AllowanceInputDialogExpenseIncom
 import com.paykidscompose.presentation.ui.theme.AllowanceInputDialogShape
 import com.paykidscompose.presentation.ui.theme.AllowanceInputDialogToggleShadowColor
 import com.paykidscompose.presentation.ui.theme.AllowanceInputToggleTextStyle
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenAddButtonVertical
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenBorderWidth1
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenDeleteButtonHorizontal
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenDeleteButtonVertical
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenElevation16
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenProgressBarHeight
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenProgressBarSize
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenProgressBarSpace
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenShape10
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenShape100
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenShape4
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenShape5
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenShape8
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenSpacer12
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenSpacer28
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenSpacer34
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenSpacer8
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenStartEndPadding
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenTopPadding
 import com.paykidscompose.presentation.ui.theme.Black
 import com.paykidscompose.presentation.ui.theme.Blue1
 import com.paykidscompose.presentation.ui.theme.CustomCardShadow
@@ -67,6 +86,7 @@ import com.paykidscompose.presentation.ui.theme.ExpenseAnalysisItemAddButtonText
 import com.paykidscompose.presentation.ui.theme.ExpenseAnalysisItemAmountTextStyle
 import com.paykidscompose.presentation.ui.theme.ExpenseAnalysisItemCategoryTextStyle
 import com.paykidscompose.presentation.ui.theme.ExpenseAnalysisItemPercentTextStyle
+import com.paykidscompose.presentation.ui.theme.ExpenseAnalysisProgressBarNameTextStyle
 import com.paykidscompose.presentation.ui.theme.Gray1
 import com.paykidscompose.presentation.ui.theme.Gray5
 import com.paykidscompose.presentation.ui.theme.Gray6
@@ -87,6 +107,11 @@ fun ExpenseAnalysis(
         mutableStateOf(
             LocalDate.now()
         )
+    }
+    var selectedAllowanceType by remember { mutableStateOf(AllowanceType.EXPENSE)}
+
+    val onSelectAllowanceType = { type: AllowanceType ->
+        selectedAllowanceType = type
     }
 
     val onMonth = { month: LocalDate ->
@@ -110,9 +135,9 @@ fun ExpenseAnalysis(
     ExpenseAnalysisScreen(
         onCategoryCard,
         currentMonth,
-        AllowanceType.EXPENSE,
+        selectedAllowanceType,
         onMonth,
-        {}
+        onSelectAllowanceType
     )
 }
 
@@ -129,7 +154,8 @@ fun ExpenseAnalysisScreen(
             AllowanceChartDTO(1, "2025-06-01", AllowanceType.EXPENSE, "편의점", 3000, "음료"),
             AllowanceChartDTO(2, "2025-06-02", AllowanceType.EXPENSE, "식비", 12000, "점심"),
             AllowanceChartDTO(3, "2025-06-03", AllowanceType.EXPENSE, "편의점", 2000, "간식"),
-            AllowanceChartDTO(4, "2025-06-04", AllowanceType.EXPENSE, "식비", 10000, "저녁")
+            AllowanceChartDTO(4, "2025-06-04", AllowanceType.EXPENSE, "식비", 10000, "저녁"),
+            AllowanceChartDTO(5, "2025-06-05", AllowanceType.EXPENSE, "기타", 10000, "저녁")
         )
     )
 
@@ -139,7 +165,11 @@ fun ExpenseAnalysisScreen(
             .fillMaxSize()
             .background(color = Gray5)
             .statusBarsPadding()
-            .padding(start = 17.dp, end = 17.dp, top = 20.dp)
+            .padding(
+                start = AnalysisScreenStartEndPadding,
+                end = AnalysisScreenStartEndPadding,
+                top = AnalysisScreenTopPadding
+            )
     ) {
 
         Row(
@@ -176,7 +206,7 @@ fun ExpenseAnalysisScreen(
             }
         }
 
-        Spacer(Modifier.height(28.dp))
+        Spacer(Modifier.height(AnalysisScreenSpacer28))
 
         Row(
             modifier = Modifier
@@ -254,7 +284,7 @@ fun ExpenseAnalysisScreen(
             }
         }
 
-        Spacer(Modifier.height(34.dp))
+        Spacer(Modifier.height(AnalysisScreenSpacer34))
 
         Text(
             stringResource(R.string.text_month_total_consume, formatAmount(150000)),
@@ -262,48 +292,49 @@ fun ExpenseAnalysisScreen(
                 .copy(color = Black)
         )
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(AnalysisScreenSpacer12))
 
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
-                .background(color = White)
-                .border(width = 1.dp, color = Gray6, shape = RoundedCornerShape(8.dp))
         ) {
             CategoryProgressBar(data)
         }
 
-        Spacer(Modifier.height(34.dp))
+        Spacer(Modifier.height(AnalysisScreenSpacer34))
 
         Button(
             onClick = {},
-            shape = RoundedCornerShape(5.dp),
+            shape = RoundedCornerShape(AnalysisScreenShape5),
             colors = ButtonDefaults.buttonColors(
                 containerColor = Gray7,
                 contentColor = White
             ),
-            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+            contentPadding = PaddingValues(
+                horizontal = AnalysisScreenDeleteButtonHorizontal,
+                vertical = AnalysisScreenDeleteButtonVertical
+            ),
             modifier = Modifier.align(Alignment.End)
         ) {
-            Text("삭제하기", style = ExpenseAnalysisDeleteButtonTextStyle)
+            Text(stringResource(R.string.text_delete), style = ExpenseAnalysisDeleteButtonTextStyle)
         }
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(AnalysisScreenSpacer12))
 
         LazyColumn(
             modifier = Modifier.fillMaxWidth()
         ) {
             items(data) {
-                AnalysisItem("편의점", -1800, "50%", onCategoryCard)
-                Spacer(Modifier.height(8.dp))
+                AnalysisItem(it.name, it.amount,
+                    "${(it.percent * 100).toInt()}%", onCategoryCard)
+                Spacer(Modifier.height(AnalysisScreenSpacer8))
             }
 
             item {
 
                 Button(
                     onClick = {},
-                    shape = RoundedCornerShape(10.dp),
+                    shape = RoundedCornerShape(AnalysisScreenShape10),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = White2,
                         contentColor = Gray7
@@ -311,15 +342,15 @@ fun ExpenseAnalysisScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .shadow(
-                            16.dp,
-                            shape = RoundedCornerShape(10.dp),
+                            AnalysisScreenElevation16,
+                            shape = RoundedCornerShape(AnalysisScreenShape10),
                             ambientColor = MyPageCardShadowColor,
                             spotColor = MyPageCardShadowColor
                         ),
-                    contentPadding = PaddingValues(vertical = 14.dp)
+                    contentPadding = PaddingValues(vertical = AnalysisScreenAddButtonVertical)
                 ) {
                     Text(
-                        "+ 추가하기",
+                        stringResource(R.string.text_add_category),
                         style = ExpenseAnalysisItemAddButtonTextStyle
                     )
                 }
@@ -393,10 +424,9 @@ private fun CategoryProgressBar(stats: List<CategoryStat>) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(20.dp)
-                .clip(RoundedCornerShape(100.dp))
-                .background(Color.White)
-                .border(1.dp, Gray6, RoundedCornerShape(100.dp))
+                .height(AnalysisScreenProgressBarHeight)
+                .clip(RoundedCornerShape(AnalysisScreenShape100))
+                .border(AnalysisScreenBorderWidth1, Gray6, RoundedCornerShape(AnalysisScreenShape100))
         ) {
             Row(Modifier.fillMaxSize()) {
                 stats.forEach { stat ->
@@ -410,11 +440,11 @@ private fun CategoryProgressBar(stats: List<CategoryStat>) {
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(AnalysisScreenShape8))
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(AnalysisScreenProgressBarSpace),
             verticalAlignment = Alignment.CenterVertically
         ) {
             stats.forEach { stat ->
@@ -423,13 +453,13 @@ private fun CategoryProgressBar(stats: List<CategoryStat>) {
                 ) {
                     Box(
                         modifier = Modifier
-                            .size(8.dp)
+                            .size(AnalysisScreenProgressBarSize)
                             .background(stat.color, shape = CircleShape)
                     )
-                    Spacer(Modifier.width(4.dp))
+                    Spacer(Modifier.width(AnalysisScreenShape4))
                     Text(
                         text = stat.name,
-                        style = TextStyle(fontSize = 12.sp, color = Black)
+                        style = ExpenseAnalysisProgressBarNameTextStyle
                     )
                 }
             }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -251,6 +251,27 @@ val AllowanceInputDialogIconHeight = 6.dp
 val AllowanceInputDialogDateItemStartEndPadding = 8.dp
 val AllowanceInputDialogDateItemTopBottomPadding = 4.dp
 
+// 용돈일기 분석 화면
+val AnalysisScreenStartEndPadding = 17.dp
+val AnalysisScreenTopPadding = 20.dp
+val AnalysisScreenSpacer8 = 8.dp
+val AnalysisScreenSpacer12 = 12.dp
+val AnalysisScreenSpacer28 = 28.dp
+val AnalysisScreenSpacer34 = 34.dp
+val AnalysisScreenShape4 = 4.dp
+val AnalysisScreenShape5 = 5.dp
+val AnalysisScreenShape8 = 8.dp
+val AnalysisScreenShape10 = 10.dp
+val AnalysisScreenShape100 = 100.dp
+val AnalysisScreenElevation16 = 16.dp
+val AnalysisScreenBorderWidth1 = 1.dp
+val AnalysisScreenDeleteButtonHorizontal = 8.dp
+val AnalysisScreenDeleteButtonVertical = 0.dp
+val AnalysisScreenAddButtonVertical = 14.dp
+val AnalysisScreenProgressBarHeight = 20.dp
+val AnalysisScreenProgressBarSpace = 16.dp
+val AnalysisScreenProgressBarSize = 8.dp
+
 // 카테고리 상세내역 화면
 val CategoryDetailScreenStartEndPadding = 17.dp
 val CategoryDetailScreenTopPadding = 70.dp

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Font.kt
@@ -388,6 +388,12 @@ val ExpenseAnalysisItemAddButtonTextStyle = TextStyle(
     fontSize = 16.sp,
     lineHeight = 18.sp
 )
+val ExpenseAnalysisProgressBarNameTextStyle = TextStyle(
+    fontFamily = NanumSquare,
+    fontWeight = FontWeight.Bold,
+    fontSize = 12.sp
+)
+
 
 // 카테고리 세부내역 스크린
 val CategoryDetailTitleTextStyle = TextStyle(

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@ z   <string name="text_quiz_number">%1$d/%2$d</string>
     <!-- 소비 상세 내역 페이지 -->
     <string name="text_delete_category">카테고리 삭제</string>
     <string name="text_add_category">+ 추가하기</string>
+    <string name="text_delete">삭제하기</string>
 
     <!-- 퀘스트 페이지 -->
     <string name="text_tab_quest">퀘스트</string>


### PR DESCRIPTION
## 📝작업 내용

> 용돈일기 분석 화면 수정했습니다.

## 작업 상세 내용

- [x] 퍼센트 이상하게 출력되는 것을 수정했습니다.
- [x] 프로그래스바에 배경 흰색 나오는 것을 수정했습니다.
- [x] 소비 수입 각각 클릭 가능하도록 수정했습니다.

### 💬리뷰 요구사항(선택)

> 뷰모델은 리포지토리 다 만들고 추가할 예정입니다.