### PR TITLE
feat: api 관련 코드 추가 apiservice 및 리포지토리들을 추가했습니다.

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.converter.moshi)
     implementation(libs.androidx.preference.ktx)
+    implementation(libs.androidx.security.crypto.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/data/src/main/java/com/paykidscompose/data/database/PayKidsPreference.kt
+++ b/data/src/main/java/com/paykidscompose/data/database/PayKidsPreference.kt
@@ -2,6 +2,8 @@ package com.paykidscompose.data.database
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 
 object PayKidsPreference {
     private const val PREFERENCE_NAME = "PayKidsPreference"
@@ -9,7 +11,14 @@ object PayKidsPreference {
 
     fun init(context: Context) {
         if (INSTANCE == null) {
-            INSTANCE = context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+            INSTANCE = EncryptedSharedPreferences.create(
+                PREFERENCE_NAME,
+                masterKeyAlias,
+                context,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
         }
     }
 

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkAuthenticator.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkAuthenticator.kt
@@ -5,9 +5,11 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
 
+// 토큰이 만료되면 갱신 해주기 위함.
+
 class NetworkAuthenticator: Authenticator {
     override fun authenticate(route: Route?, response: Response): Request? {
-        with(route) {
+        route.run {
             response.request.newBuilder()
             if (response.code == 401) {
 

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkInterceptor.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkInterceptor.kt
@@ -1,16 +1,25 @@
 package com.paykidscompose.data.network
 
 import com.paykidscompose.data.database.PayKidsPreference
+import com.paykidscompose.data.util.ACCESS_TOKEN
+import com.paykidscompose.data.util.INTERCEPTOR_HEADER
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class NetworkInterceptor: Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        with(chain) {
+class NetworkInterceptor : Interceptor {
+    // 애노테이션 헤더를 사용하지 않고 인터셉터로 요청을 가로채서 헤더를 추가하기 위해 구현
+    override fun intercept(chain: Interceptor.Chain): Response = chain.run {
+        val url = request().url.encodedPath
+        if (url.contains("/auth/login") || url.contains("/auth/refresh")) {
+            proceed(request())
+        } else {
             val newRequest = request().newBuilder()
-                .addHeader("Authorization", "Bearer ${PayKidsPreference.getInstance().getString("accessToken", "")}")
+                .addHeader(
+                    INTERCEPTOR_HEADER,
+                    "Bearer ${PayKidsPreference.getInstance().getString(ACCESS_TOKEN, "")}"
+                )
                 .build()
-            return proceed(newRequest)
+            proceed(newRequest)
         }
     }
 }

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.paykidscompose.data.network
 import com.paykidscompose.data.BuildConfig
 import com.paykidscompose.data.network.service.AchievementApiService
 import com.paykidscompose.data.network.service.AuthApiService
+import com.paykidscompose.data.network.service.ExpenseAllowanceApiService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -18,14 +19,13 @@ object NetworkModule {
         .client(client)
         .build()
 
-    private val achievementApiService = retrofit.create(AchievementApiService::class.java)
-    private val authApiService = retrofit.create(AuthApiService::class.java)
+    private val achievementApiService by lazy { retrofit.create(AchievementApiService::class.java) }
+    private val authApiService by lazy { retrofit.create(AuthApiService::class.java) }
+    private val expenseApiService by lazy { retrofit.create(ExpenseAllowanceApiService::class.java) }
 
-    fun provideAchievementApiService(): AchievementApiService {
-        return achievementApiService
-    }
+    fun provideAchievementApiService(): AchievementApiService = achievementApiService
 
-    fun provideAuthApiService(): AuthApiService {
-        return authApiService
-    }
+    fun provideAuthApiService(): AuthApiService = authApiService
+
+    fun provideExpenseApiService(): ExpenseAllowanceApiService = expenseApiService
 }

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
@@ -4,6 +4,7 @@ import com.paykidscompose.data.BuildConfig
 import com.paykidscompose.data.network.service.AchievementApiService
 import com.paykidscompose.data.network.service.AuthApiService
 import com.paykidscompose.data.network.service.ExpenseAllowanceApiService
+import com.paykidscompose.data.network.service.ExpenseCategoryApiService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -22,10 +23,13 @@ object NetworkModule {
     private val achievementApiService by lazy { retrofit.create(AchievementApiService::class.java) }
     private val authApiService by lazy { retrofit.create(AuthApiService::class.java) }
     private val expenseApiService by lazy { retrofit.create(ExpenseAllowanceApiService::class.java) }
+    private val expenseCategoryApiService by lazy { retrofit.create(ExpenseCategoryApiService::class.java) }
 
     fun provideAchievementApiService(): AchievementApiService = achievementApiService
 
     fun provideAuthApiService(): AuthApiService = authApiService
 
     fun provideExpenseApiService(): ExpenseAllowanceApiService = expenseApiService
+
+    fun provideExpenseCategoryApiService(): ExpenseCategoryApiService = expenseCategoryApiService
 }

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.paykidscompose.data.network.service.AchievementApiService
 import com.paykidscompose.data.network.service.AuthApiService
 import com.paykidscompose.data.network.service.ExpenseAllowanceApiService
 import com.paykidscompose.data.network.service.ExpenseCategoryApiService
+import com.paykidscompose.data.network.service.IncomeAllowanceApiService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -24,6 +25,7 @@ object NetworkModule {
     private val authApiService by lazy { retrofit.create(AuthApiService::class.java) }
     private val expenseApiService by lazy { retrofit.create(ExpenseAllowanceApiService::class.java) }
     private val expenseCategoryApiService by lazy { retrofit.create(ExpenseCategoryApiService::class.java) }
+    private val incomeApiService by lazy { retrofit.create(IncomeAllowanceApiService::class.java) }
 
     fun provideAchievementApiService(): AchievementApiService = achievementApiService
 
@@ -32,4 +34,6 @@ object NetworkModule {
     fun provideExpenseApiService(): ExpenseAllowanceApiService = expenseApiService
 
     fun provideExpenseCategoryApiService(): ExpenseCategoryApiService = expenseCategoryApiService
+
+    fun provideIncomeApiService(): IncomeAllowanceApiService = incomeApiService
 }

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.paykidscompose.data.network.service.AuthApiService
 import com.paykidscompose.data.network.service.ExpenseAllowanceApiService
 import com.paykidscompose.data.network.service.ExpenseCategoryApiService
 import com.paykidscompose.data.network.service.IncomeAllowanceApiService
+import com.paykidscompose.data.network.service.IncomeCategoryApiService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -26,6 +27,7 @@ object NetworkModule {
     private val expenseApiService by lazy { retrofit.create(ExpenseAllowanceApiService::class.java) }
     private val expenseCategoryApiService by lazy { retrofit.create(ExpenseCategoryApiService::class.java) }
     private val incomeApiService by lazy { retrofit.create(IncomeAllowanceApiService::class.java) }
+    private val incomeCategoryApiService by lazy { retrofit.create(IncomeCategoryApiService::class.java) }
 
     fun provideAchievementApiService(): AchievementApiService = achievementApiService
 
@@ -36,4 +38,6 @@ object NetworkModule {
     fun provideExpenseCategoryApiService(): ExpenseCategoryApiService = expenseCategoryApiService
 
     fun provideIncomeApiService(): IncomeAllowanceApiService = incomeApiService
+
+    fun provideIncomeCategoryApiService(): IncomeCategoryApiService = incomeCategoryApiService
 }

--- a/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.paykidscompose.data.network.service.ExpenseAllowanceApiService
 import com.paykidscompose.data.network.service.ExpenseCategoryApiService
 import com.paykidscompose.data.network.service.IncomeAllowanceApiService
 import com.paykidscompose.data.network.service.IncomeCategoryApiService
+import com.paykidscompose.data.network.service.UserApiService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -28,6 +29,7 @@ object NetworkModule {
     private val expenseCategoryApiService by lazy { retrofit.create(ExpenseCategoryApiService::class.java) }
     private val incomeApiService by lazy { retrofit.create(IncomeAllowanceApiService::class.java) }
     private val incomeCategoryApiService by lazy { retrofit.create(IncomeCategoryApiService::class.java) }
+    private val userApiService by lazy { retrofit.create(UserApiService::class.java) }
 
     fun provideAchievementApiService(): AchievementApiService = achievementApiService
 
@@ -40,4 +42,6 @@ object NetworkModule {
     fun provideIncomeApiService(): IncomeAllowanceApiService = incomeApiService
 
     fun provideIncomeCategoryApiService(): IncomeCategoryApiService = incomeCategoryApiService
+
+    fun provideUserApiService(): UserApiService = userApiService
 }

--- a/data/src/main/java/com/paykidscompose/data/network/service/AuthApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/AuthApiService.kt
@@ -2,12 +2,13 @@ package com.paykidscompose.data.network.service
 
 import com.paykidscompose.data.model.BaseResponse
 import com.paykidscompose.data.model.user.LoginDTO
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthApiService {
     @POST("/auth/refresh")
-    suspend fun fetchRefreshToken(refreshToken: String): BaseResponse<LoginDTO>
+    suspend fun fetchRefreshToken(@Header("Authorization") refreshToken: String): BaseResponse<LoginDTO>
 
     @POST("/auth/login")
-    suspend fun fetchLoginToken(idToken: String): BaseResponse<LoginDTO>
+    suspend fun fetchLoginToken(@Header("Authorization") idToken: String): BaseResponse<LoginDTO>
 }

--- a/data/src/main/java/com/paykidscompose/data/network/service/ExpenseAllowanceApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/ExpenseAllowanceApiService.kt
@@ -1,0 +1,62 @@
+package com.paykidscompose.data.network.service
+
+import com.paykidscompose.data.model.BaseResponse
+import com.paykidscompose.data.model.allowance.AllowanceChartAmountDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartCategoryDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartDTO
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface ExpenseAllowanceApiService {
+    @DELETE("/expense/allowance/delete")
+    suspend fun deleteExpense(@Query("id") id: Int): BaseResponse<Boolean>
+
+    @GET("/expense/allowance/month-total-amount")
+    suspend fun getExpenseMonthTotalAmount(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<Int>
+
+    @GET("/expense/allowance/month-most-category")
+    suspend fun getExpenseMonthMostCategory(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<List<AllowanceChartCategoryDTO>>
+
+    @GET("/expense/allowance/month-daily-amount")
+    suspend fun getExpenseMonthDailyAmount(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<List<AllowanceChartAmountDTO>>
+
+    @GET("/expense/allowance/month-category")
+    suspend fun getExpenseMonthCategory(
+        @Query("year") year: Int,
+        @Query("month") month: Int,
+        @Query("category") category: String
+    ): BaseResponse<List<AllowanceChartDTO>>
+
+    @GET("/expense/allowance/month-all-category")
+    suspend fun getExpenseMonthAllCategory(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<List<AllowanceChartCategoryDTO>>
+
+    @GET("/expense/allowance/day")
+    suspend fun getExpenseDay(
+        @Query("localDate") localDate: String
+    ): BaseResponse<List<AllowanceChartDTO>>
+
+    @POST("/expense/allowance/save")
+    suspend fun saveExpense(
+        @Body request: AllowanceChartDTO
+    ): BaseResponse<Boolean>
+
+    @POST("/expense/allowance/replace")
+    suspend fun replaceExpense(
+        @Body request: AllowanceChartDTO
+    ): BaseResponse<Boolean>
+}

--- a/data/src/main/java/com/paykidscompose/data/network/service/ExpenseCategoryApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/ExpenseCategoryApiService.kt
@@ -1,0 +1,25 @@
+package com.paykidscompose.data.network.service
+
+import com.paykidscompose.data.model.BaseResponse
+import com.paykidscompose.data.model.allowance.CategoryDTO
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface ExpenseCategoryApiService {
+    @DELETE("/expense/category/delete-category")
+    suspend fun deleteExpenseCategory(
+        @Query("category") category: String
+    ): BaseResponse<Boolean>
+
+    @GET ("/expense/category/category-list")
+    suspend fun getExpenseCategoryList(): BaseResponse<CategoryDTO>
+
+    @POST("/expense/category/save-category")
+    suspend fun saveExpenseCategory(
+        @Query("category") category: String,
+        @Body request: CategoryDTO
+    ): BaseResponse<Boolean>
+}

--- a/data/src/main/java/com/paykidscompose/data/network/service/ExpenseCategoryApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/ExpenseCategoryApiService.kt
@@ -15,11 +15,10 @@ interface ExpenseCategoryApiService {
     ): BaseResponse<Boolean>
 
     @GET ("/expense/category/category-list")
-    suspend fun getExpenseCategoryList(): BaseResponse<CategoryDTO>
+    suspend fun getExpenseCategoryList(): BaseResponse<List<CategoryDTO>>
 
     @POST("/expense/category/save-category")
     suspend fun saveExpenseCategory(
-        @Query("category") category: String,
-        @Body request: CategoryDTO
+        @Query("category") category: String
     ): BaseResponse<Boolean>
 }

--- a/data/src/main/java/com/paykidscompose/data/network/service/IncomeAllowanceApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/IncomeAllowanceApiService.kt
@@ -1,0 +1,58 @@
+package com.paykidscompose.data.network.service
+
+import com.paykidscompose.data.model.BaseResponse
+import com.paykidscompose.data.model.allowance.AllowanceChartAmountDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartCategoryDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartDTO
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface IncomeAllowanceApiService {
+    @DELETE("/income/allowance/delete")
+    suspend fun deleteIncome(
+        @Query("id") id: Int
+    ): BaseResponse<Boolean>
+
+    @GET("/income/allowance/month-total-amount")
+    suspend fun getIncomeMonthTotalAmount(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<Int>
+
+    @GET("/income/allowance/month-daily-amount")
+    suspend fun getIncomeMonthDailyAmount(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<List<AllowanceChartAmountDTO>>
+
+    @GET("/income/allowance/month-category")
+    suspend fun getIncomeMonthCategory(
+        @Query("year") year: Int,
+        @Query("month") month: Int,
+        @Query("category") category: String
+    ): BaseResponse<List<AllowanceChartDTO>>
+
+    @GET("/income/allowance/month-all-category")
+    suspend fun getIncomeMonthAllCategory(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): BaseResponse<List<AllowanceChartCategoryDTO>>
+
+    @GET("/income/allowance/day")
+    suspend fun getIncomeDay(
+        @Query("localDate") localDate: String
+    ): BaseResponse<List<AllowanceChartDTO>>
+
+    @POST("/income/allowance/save")
+    suspend fun saveIncome(
+        @Body request: AllowanceChartDTO
+    ): BaseResponse<Boolean>
+
+    @POST("/income/allowance/replace")
+    suspend fun replaceIncome(
+        @Body request: AllowanceChartDTO
+    ): BaseResponse<Boolean>
+}

--- a/data/src/main/java/com/paykidscompose/data/network/service/IncomeCategoryApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/IncomeCategoryApiService.kt
@@ -1,0 +1,24 @@
+package com.paykidscompose.data.network.service
+
+import com.paykidscompose.data.model.BaseResponse
+import com.paykidscompose.data.model.allowance.CategoryDTO
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface IncomeCategoryApiService {
+
+    @DELETE("/income/category/delete-category")
+    suspend fun deleteIncomeCategory(
+        @Query("category") category: String
+    ): BaseResponse<Boolean>
+
+    @GET("/income/category/category-list")
+    suspend fun getIncomeCategoryList(): BaseResponse<List<CategoryDTO>>
+
+    @POST("/income/category/save-category")
+    suspend fun saveIncomeCategory(
+        @Query("category") category: String
+    ): BaseResponse<Boolean>
+}

--- a/data/src/main/java/com/paykidscompose/data/network/service/UserApiService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/UserApiService.kt
@@ -1,0 +1,32 @@
+package com.paykidscompose.data.network.service
+
+import com.paykidscompose.data.model.BaseResponse
+import com.paykidscompose.data.model.user.UserDTO
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface UserApiService {
+    @DELETE("/user/delete")
+    suspend fun deleteUser(): BaseResponse<String>
+
+    @GET("/user/info")
+    suspend fun getUser(): BaseResponse<UserDTO>
+
+    @POST("/user/profile-image/change")
+    suspend fun replaceProfileImage(
+        @Body file: String
+    ): BaseResponse<String>
+
+    @POST("/user/nickname/save")
+    suspend fun saveNickname(
+        @Query("nickname") nickname: String
+    ): BaseResponse<String>
+
+    @POST("/user/nickname/change")
+    suspend fun replaceNickname(
+        @Query("newNickname") newNickname: String
+    ): BaseResponse<String>
+}

--- a/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
@@ -12,7 +12,8 @@ import com.paykidscompose.data.util.REFRESH_TOKEN
 class AuthRepositoryImpl(private val authApiService: AuthApiService = NetworkModule.provideAuthApiService()) {
     suspend fun fetchRefreshToken(refreshToken: String): DataResourceResult<LoginDTO> {
         return runCatching {
-            authApiService.fetchRefreshToken(refreshToken)
+            val header = "Bearer $refreshToken"
+            authApiService.fetchRefreshToken(header)
         }.fold(
             onSuccess = { DataResourceResult.Success(it.data) },
             onFailure = { DataResourceResult.Failure(it) }
@@ -21,7 +22,8 @@ class AuthRepositoryImpl(private val authApiService: AuthApiService = NetworkMod
 
     suspend fun fetchLoginToken(idToken: String): DataResourceResult<Unit> {
         return runCatching {
-            val token = authApiService.fetchLoginToken(idToken)
+            val header = "Bearer $idToken"
+            val token = authApiService.fetchLoginToken(header)
             PayKidsPreference.getInstance().edit {
                 putString(ACCESS_TOKEN, token.data.accessToken)
                 putString(REFRESH_TOKEN, token.data.refreshToken)

--- a/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
@@ -1,29 +1,34 @@
 package com.paykidscompose.data.repositories
 
+import androidx.core.content.edit
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.data.database.PayKidsPreference
-import com.paykidscompose.data.model.BaseResponse
 import com.paykidscompose.data.model.user.LoginDTO
 import com.paykidscompose.data.network.NetworkModule
 import com.paykidscompose.data.network.service.AuthApiService
-import androidx.core.content.edit
+import com.paykidscompose.data.util.ACCESS_TOKEN
+import com.paykidscompose.data.util.REFRESH_TOKEN
 
 class AuthRepositoryImpl(private val authApiService: AuthApiService = NetworkModule.provideAuthApiService()) {
-    suspend fun fetchRefreshToken(refreshToken: String): DataResourceResult<BaseResponse<LoginDTO>> {
-        runCatching { authApiService.fetchRefreshToken(refreshToken) }
-            .getOrElse { return DataResourceResult.Failure(it) }
-            .let { return DataResourceResult.Success(it) }
+    suspend fun fetchRefreshToken(refreshToken: String): DataResourceResult<LoginDTO> {
+        return runCatching {
+            authApiService.fetchRefreshToken(refreshToken)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
     }
 
     suspend fun fetchLoginToken(idToken: String): DataResourceResult<Unit> {
-        runCatching {
+        return runCatching {
             val token = authApiService.fetchLoginToken(idToken)
-
             PayKidsPreference.getInstance().edit {
-                putString("accessToken", token.data.accessToken)
-                    .putString("refreshToken", token.data.refreshToken)
+                putString(ACCESS_TOKEN, token.data.accessToken)
+                putString(REFRESH_TOKEN, token.data.refreshToken)
             }
-        }.getOrElse { return DataResourceResult.Failure(it) }
-            .let { return DataResourceResult.Success(Unit) }
+        }.fold(
+            onSuccess = { DataResourceResult.Success(Unit) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
     }
 }

--- a/data/src/main/java/com/paykidscompose/data/repositories/ExpenseAllowanceRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/ExpenseAllowanceRepositoryImpl.kt
@@ -1,0 +1,114 @@
+package com.paykidscompose.data.repositories
+
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.data.model.allowance.AllowanceChartAmountDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartCategoryDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartDTO
+import com.paykidscompose.data.network.NetworkModule
+import com.paykidscompose.data.network.service.ExpenseAllowanceApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class ExpenseAllowanceRepositoryImpl(private val expenseApiService: ExpenseAllowanceApiService = NetworkModule.provideExpenseApiService()) {
+
+    suspend fun deleteExpense(id: Int): DataResourceResult<Boolean> {
+        return runCatching {
+            expenseApiService.deleteExpense(id)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun saveExpense(request: AllowanceChartDTO): DataResourceResult<Boolean> {
+        return runCatching {
+            expenseApiService.saveExpense(request)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun replaceExpense(request: AllowanceChartDTO): DataResourceResult<Boolean> {
+        return runCatching {
+            expenseApiService.replaceExpense(request)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun getExpenseMonthTotalAmount(year: Int, month: Int): DataResourceResult<Int> {
+        return runCatching {
+            expenseApiService.getExpenseMonthTotalAmount(year, month)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    fun getExpenseMonthMostCategory(
+        year: Int,
+        month: Int
+    ): Flow<DataResourceResult<List<AllowanceChartCategoryDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            expenseApiService.getExpenseMonthMostCategory(year, month)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getExpenseMonthDailyAmount(
+        year: Int,
+        month: Int
+    ): Flow<DataResourceResult<List<AllowanceChartAmountDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            expenseApiService.getExpenseMonthDailyAmount(year, month)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getExpenseMonthCategory(
+        year: Int,
+        month: Int,
+        category: String
+    ): Flow<DataResourceResult<List<AllowanceChartDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            expenseApiService.getExpenseMonthCategory(year, month, category)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getExpenseMonthAllCategory(
+        year: Int,
+        month: Int
+    ): Flow<DataResourceResult<List<AllowanceChartCategoryDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            expenseApiService.getExpenseMonthAllCategory(year, month)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getExpenseDay(
+        localDate: String
+    ): Flow<DataResourceResult<List<AllowanceChartDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            expenseApiService.getExpenseDay(localDate)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/repositories/ExpenseCategoryRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/ExpenseCategoryRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.paykidscompose.data.repositories
+
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.data.model.allowance.CategoryDTO
+import com.paykidscompose.data.network.NetworkModule
+import com.paykidscompose.data.network.service.ExpenseCategoryApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class ExpenseCategoryRepositoryImpl(private val categoryApiService: ExpenseCategoryApiService = NetworkModule.provideExpenseCategoryApiService()) {
+
+    suspend fun deleteExpenseCategory(category: String): DataResourceResult<Boolean> {
+        return runCatching {
+            categoryApiService.deleteExpenseCategory(category)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data)},
+            onFailure = { DataResourceResult.Failure(it)}
+        )
+    }
+
+    suspend fun saveExpenseCategory(category: String, request: CategoryDTO): DataResourceResult<Boolean> {
+        return runCatching {
+            categoryApiService.saveExpenseCategory(category, request)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data)},
+            onFailure = { DataResourceResult.Failure(it)}
+        )
+    }
+
+    fun getExpenseCategoryList(): Flow<DataResourceResult<CategoryDTO>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            categoryApiService.getExpenseCategoryList()
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data))},
+            onFailure = { emit(DataResourceResult.Failure(it))}
+        )
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/repositories/ExpenseCategoryRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/ExpenseCategoryRepositoryImpl.kt
@@ -18,16 +18,16 @@ class ExpenseCategoryRepositoryImpl(private val categoryApiService: ExpenseCateg
         )
     }
 
-    suspend fun saveExpenseCategory(category: String, request: CategoryDTO): DataResourceResult<Boolean> {
+    suspend fun saveExpenseCategory(category: String): DataResourceResult<Boolean> {
         return runCatching {
-            categoryApiService.saveExpenseCategory(category, request)
+            categoryApiService.saveExpenseCategory(category)
         }.fold(
             onSuccess = { DataResourceResult.Success(it.data)},
             onFailure = { DataResourceResult.Failure(it)}
         )
     }
 
-    fun getExpenseCategoryList(): Flow<DataResourceResult<CategoryDTO>> = flow {
+    fun getExpenseCategoryList(): Flow<DataResourceResult<List<CategoryDTO>>> = flow {
         emit(DataResourceResult.Loading)
         runCatching {
             categoryApiService.getExpenseCategoryList()

--- a/data/src/main/java/com/paykidscompose/data/repositories/IncomeAllowanceRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/IncomeAllowanceRepositoryImpl.kt
@@ -1,0 +1,101 @@
+package com.paykidscompose.data.repositories
+
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.data.model.allowance.AllowanceChartAmountDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartCategoryDTO
+import com.paykidscompose.data.model.allowance.AllowanceChartDTO
+import com.paykidscompose.data.network.NetworkModule
+import com.paykidscompose.data.network.service.IncomeAllowanceApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class IncomeAllowanceRepositoryImpl(private val incomeAllowanceApiService: IncomeAllowanceApiService = NetworkModule.provideIncomeApiService()) {
+
+    suspend fun deleteIncome(id: Int): DataResourceResult<Boolean> {
+        return runCatching {
+            incomeAllowanceApiService.deleteIncome(id)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun saveIncome(request: AllowanceChartDTO): DataResourceResult<Boolean> {
+        return runCatching {
+            incomeAllowanceApiService.saveIncome(request)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun replaceIncome(request: AllowanceChartDTO): DataResourceResult<Boolean> {
+        return runCatching {
+            incomeAllowanceApiService.replaceIncome(request)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun getIncomeMonthTotalAmount(year: Int, month: Int): DataResourceResult<Int> {
+        return runCatching {
+            incomeAllowanceApiService.getIncomeMonthTotalAmount(year, month)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    fun getIncomeMonthDailyAmount(
+        year: Int,
+        month: Int
+    ): Flow<DataResourceResult<List<AllowanceChartAmountDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            incomeAllowanceApiService.getIncomeMonthDailyAmount(year, month)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getIncomeMonthCategory(
+        year: Int,
+        month: Int,
+        category: String
+    ): Flow<DataResourceResult<List<AllowanceChartDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            incomeAllowanceApiService.getIncomeMonthCategory(year, month, category)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getIncomeMonthAllCategory(
+        year: Int,
+        month: Int
+    ): Flow<DataResourceResult<List<AllowanceChartCategoryDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            incomeAllowanceApiService.getIncomeMonthAllCategory(year, month)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+
+    fun getIncomeDay(
+        localDate: String
+    ): Flow<DataResourceResult<List<AllowanceChartDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            incomeAllowanceApiService.getIncomeDay(localDate)
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/repositories/IncomeCategoryRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/IncomeCategoryRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.paykidscompose.data.repositories
+
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.data.model.allowance.CategoryDTO
+import com.paykidscompose.data.network.NetworkModule
+import com.paykidscompose.data.network.service.IncomeCategoryApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class IncomeCategoryRepositoryImpl(private val incomeCategoryApiService: IncomeCategoryApiService = NetworkModule.provideIncomeCategoryApiService()) {
+
+    suspend fun deleteIncomeCategory(category: String): DataResourceResult<Boolean> {
+        return runCatching {
+            incomeCategoryApiService.deleteIncomeCategory(category)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun saveIncomeCategory(category: String): DataResourceResult<Boolean> {
+        return runCatching {
+            incomeCategoryApiService.saveIncomeCategory(category)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    fun getIncomeCategoryList(): Flow<DataResourceResult<List<CategoryDTO>>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            incomeCategoryApiService.getIncomeCategoryList()
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/repositories/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/UserRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.paykidscompose.data.repositories
+
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.data.model.user.UserDTO
+import com.paykidscompose.data.network.NetworkModule
+import com.paykidscompose.data.network.service.UserApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class UserRepositoryImpl(private val userApiService: UserApiService = NetworkModule.provideUserApiService()) {
+
+    suspend fun deleteUser(): DataResourceResult<String> {
+        return runCatching {
+            userApiService.deleteUser()
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun saveNickname(nickname: String): DataResourceResult<String> {
+        return runCatching {
+            userApiService.saveNickname(nickname)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun replaceNickname(newNickname: String): DataResourceResult<String> {
+        return runCatching {
+            userApiService.replaceNickname(newNickname)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun replaceProfileImage(file: String): DataResourceResult<String> {
+        return runCatching {
+            userApiService.replaceProfileImage(file)
+        }.fold(
+            onSuccess = { DataResourceResult.Success(it.data) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    fun getUser(): Flow<DataResourceResult<UserDTO>> = flow {
+        emit(DataResourceResult.Loading)
+        runCatching {
+            userApiService.getUser()
+        }.fold(
+            onSuccess = { emit(DataResourceResult.Success(it.data)) },
+            onFailure = { emit(DataResourceResult.Failure(it)) }
+        )
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/util/Constants.kt
+++ b/data/src/main/java/com/paykidscompose/data/util/Constants.kt
@@ -1,0 +1,5 @@
+package com.paykidscompose.data.util
+
+const val ACCESS_TOKEN = "accessToken"
+const val REFRESH_TOKEN = "refreshToken"
+const val INTERCEPTOR_HEADER = "Authorization"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ moshiKotlin = "1.15.2"
 retrofit = "3.0.0"
 converterMoshi = "3.0.0"
 preferenceKtx = "1.2.1"
+securityCryptoKtx = "1.1.0-alpha07"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -51,6 +52,7 @@ moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.re
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "converterMoshi" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferenceKtx" }
+androidx-security-crypto-ktx = { group = "androidx.security", name = "security-crypto-ktx", version.ref = "securityCryptoKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 📝작업 내용

> 용돈일기의 소비 수입, 유저, 수입 소비 카테고리의 api서비스와 리포지토리를 추가했습니다.
> 프리퍼런스를 encryptedsharedpreferences로 수정 
> 인터셉터에 로그인이랑 토큰 갱신하는 url은 헤더 적용 안되도록 수정했습니다.
> 네트워크 모듈 오브젝트에 by lazy로 사용될 때 초기화 되도록 수정했습니다.
> with 함수 사용 부분을 run으로 수정했습니다.

## 작업 상세 내용

- [x] 각 api 서비스와 리포지토리 추가
- [x] encryptedsharedpreferences로 수정
- [x] 로그인이랑 토큰 갱신하는 url에는 인터셉터 헤더 적용 안되도록 수정
- [x] by lazy로 수정
- [x] run 함수로 수정
- [x] auth 리포지토리에서 bearer을 붙인 문자열을 전달하도록 수정

### 💬리뷰 요구사항(선택)

> 이슈를 남기긴 했는데 매퍼랑 common에 모델 추가하고 DTO가 반환되는 것을 수정할 예정입니다.
