### PR TITLE
feat: 카카오 로그인, 로그아웃 구현

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("kotlin-parcelize")
 }
 
 android {
@@ -43,6 +44,8 @@ android {
 
 dependencies {
     implementation(project(":common"))
+
+    implementation(libs.v2.user)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <activity
+            android:name=".network.service.authentication.KakaoLoginHelperActivity"
+            android:exported="false" />
+    </application>
 </manifest>

--- a/data/src/main/java/com/paykidscompose/data/model/Token.kt
+++ b/data/src/main/java/com/paykidscompose/data/model/Token.kt
@@ -1,0 +1,16 @@
+package com.paykidscompose.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.util.Date
+
+@Parcelize
+data class Token(
+    val userId: String,
+    val profileUrl: String,
+    val idToken: String,
+    val accessToken: String,
+    val accessTokenExpiresAt: Date,
+    val refreshToken: String,
+    val refreshTokenExpiresAt: Date
+): Parcelable

--- a/data/src/main/java/com/paykidscompose/data/network/service/authentication/KakaoLoginHelperActivity.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/authentication/KakaoLoginHelperActivity.kt
@@ -1,0 +1,145 @@
+package com.paykidscompose.data.network.service.authentication
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.user.UserApiClient
+import com.kakao.sdk.user.model.User
+import com.paykidscompose.data.model.Token
+
+
+internal class KakaoLoginHelperActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (!UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
+            loginKakaoWeb(
+                onSuccess = { finishActivityWithSuccessResult(it) },
+                onFailure = { finishActivityWithFailureResult() }
+            )
+            return
+        }
+
+        loginKakaoTalk(
+            onSuccess = { finishActivityWithSuccessResult(it) },
+            onFailure = {
+                loginKakaoWeb(
+                    onSuccess = { finishActivityWithSuccessResult(it) },
+                    onFailure = { finishActivityWithFailureResult() }
+                )
+            }
+        )
+    }
+
+    private fun finishActivityWithSuccessResult(token: Token) {
+        val intent = Intent().apply {
+            putExtra(TOKEN_PARAM, token)
+        }
+        setResult(RESULT_OK, intent)
+        activityResultListener?.invoke(RESULT_OK, intent)
+        activityResultListener = null
+        finish()
+    }
+
+    private fun finishActivityWithFailureResult() {
+        setResult(RESULT_CANCELED)
+        activityResultListener?.invoke(RESULT_CANCELED, null)
+        activityResultListener = null
+        finish()
+    }
+
+    private fun loginKakaoWeb(
+        onSuccess: (Token) -> Unit,
+        onFailure: (Throwable?) -> Unit,
+    ) {
+        try {
+            UserApiClient.instance.loginWithKakaoAccount(
+                context = this@KakaoLoginHelperActivity,
+                callback = { token, error ->
+                    if (error != null || token == null) {
+                        Log.e(TAG, "카카오계정으로 로그인 실패", error)
+                        onFailure(error)
+                        return@loginWithKakaoAccount
+                    }
+                    UserApiClient.instance.me { user, error ->
+                        if (user == null || error != null) {
+                            Log.e(TAG, "카카오 유저정보 로드 실패", error)
+                            onFailure(error)
+                            return@me
+                        }
+                        onSuccess(handleCallbackToken(token, user))
+                    }
+                }
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "loginKakaoWeb 예외 발생", e)
+            onFailure(e)
+        }
+    }
+
+    private fun loginKakaoTalk(
+        onSuccess: (Token) -> Unit,
+        onFailure: (Throwable?) -> Unit,
+    ) {
+        try {
+            UserApiClient.instance.loginWithKakaoTalk(
+                context = this@KakaoLoginHelperActivity,
+                callback = { token: OAuthToken?, error: Throwable? ->
+                    if (error != null || token == null) {
+                        Log.e(TAG, "카카오톡 로그인 실패", error)
+                        onFailure(error)
+                        return@loginWithKakaoTalk
+                    }
+                    UserApiClient.instance.me { user, error ->
+                        if (user == null || error != null) {
+                            Log.e(TAG, "카카오 유저정보 로드 실패", error)
+                            onFailure(error)
+                            return@me
+                        }
+                        onSuccess(handleCallbackToken(token, user))
+                    }
+                }
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "loginKakaoTalk 예외 발생", e)
+            onFailure(e)
+        }
+    }
+
+    private fun handleCallbackToken(
+        token: OAuthToken,
+        user: User?,
+    ): Token {
+        Log.i(TAG, "카카오계정으로 로그인 성공")
+        return Token(
+            userId = user?.id?.toString() ?: "null",
+            profileUrl = user?.kakaoAccount?.profile?.profileImageUrl ?: "null",
+            idToken = token.idToken ?: throw IllegalStateException("idToken이 존재하지 않습니다."),
+            accessToken = token.accessToken,
+            accessTokenExpiresAt = token.accessTokenExpiresAt,
+            refreshToken = token.refreshToken,
+            refreshTokenExpiresAt = token.refreshTokenExpiresAt
+        )
+    }
+
+    companion object {
+        private const val TAG = "KakaoLoginHelperActivity"
+        internal const val TOKEN_PARAM = "token"
+
+        private var activityResultListener: ((resultCode: Int, data: Intent?) -> Unit)? = null
+
+        fun startActivityForResult(
+            context: Context,
+            intent: Intent,
+            resultListener: (resultCode: Int, data: Intent?) -> Unit,
+        ) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION)
+            context.startActivity(intent)
+            activityResultListener = resultListener
+        }
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/network/service/authentication/KakaoLoginService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/authentication/KakaoLoginService.kt
@@ -1,0 +1,50 @@
+package com.paykidscompose.data.network.service.authentication
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.kakao.sdk.user.UserApiClient
+import com.paykidscompose.data.model.Token
+import com.paykidscompose.data.util.getCustomParcelableExtra
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class KakaoLoginService(
+    private val appContext: Context
+) : SocialLoginService {
+    override suspend fun login(): Token = suspendCancellableCoroutine { continuation ->
+        KakaoLoginHelperActivity.startActivityForResult(
+            context = appContext,
+            intent = Intent(appContext, KakaoLoginHelperActivity::class.java)
+        ) { _: Int, data: Intent? ->
+            val token = data?.getCustomParcelableExtra(
+                name = KakaoLoginHelperActivity.TOKEN_PARAM,
+                clazz = Token::class.java
+            )
+
+            if(token == null) {
+                continuation.resumeWithException(IllegalStateException())
+                return@startActivityForResult
+            }
+
+            continuation.resume(token)
+        }
+    }
+
+    override suspend fun logout(): Result<Unit> = suspendCancellableCoroutine { continuation ->
+        UserApiClient.instance.logout { error ->
+            if(error != null) {
+                Log.e(TAG, "카카오 로그아웃 실패", error)
+                continuation.resume(Result.failure(error))
+            } else {
+                Log.i(TAG, "카카오 로그아웃 성공")
+                continuation.resume(Result.success(Unit))
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "KakaoLoginService"
+    }
+}

--- a/data/src/main/java/com/paykidscompose/data/network/service/authentication/SocialLoginService.kt
+++ b/data/src/main/java/com/paykidscompose/data/network/service/authentication/SocialLoginService.kt
@@ -1,0 +1,8 @@
+package com.paykidscompose.data.network.service.authentication
+
+import com.paykidscompose.data.model.Token
+
+internal interface SocialLoginService {
+    suspend fun login(): Token
+    suspend fun logout(): Result<Unit>
+}

--- a/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
@@ -1,35 +1,53 @@
 package com.paykidscompose.data.repositories
 
+import android.util.Log
 import androidx.core.content.edit
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.data.database.PayKidsPreference
 import com.paykidscompose.data.model.user.LoginDTO
 import com.paykidscompose.data.network.NetworkModule
 import com.paykidscompose.data.network.service.AuthApiService
+import com.paykidscompose.data.network.service.authentication.KakaoLoginService
 import com.paykidscompose.data.util.ACCESS_TOKEN
 import com.paykidscompose.data.util.REFRESH_TOKEN
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-class AuthRepositoryImpl(private val authApiService: AuthApiService = NetworkModule.provideAuthApiService()) {
-    suspend fun fetchRefreshToken(refreshToken: String): DataResourceResult<LoginDTO> {
+class AuthRepositoryImpl(
+    private val authApiService: AuthApiService = NetworkModule.provideAuthApiService(),
+    private val kakaoLoginService: KakaoLoginService
+) {
+    suspend fun fetchRefreshToken(): DataResourceResult<LoginDTO> {
         return runCatching {
-            val header = "Bearer $refreshToken"
-            authApiService.fetchRefreshToken(header)
+            val token = PayKidsPreference.getInstance().getString(REFRESH_TOKEN, null)
+                ?: throw IllegalStateException("저장소에 REFRESH TOKEN이 없습니다.")
+            authApiService.fetchRefreshToken(token)
         }.fold(
             onSuccess = { DataResourceResult.Success(it.data) },
             onFailure = { DataResourceResult.Failure(it) }
         )
     }
 
-    suspend fun fetchLoginToken(idToken: String): DataResourceResult<Unit> {
+    suspend fun fetchLoginToken(): DataResourceResult<Unit> {
         return runCatching {
-            val header = "Bearer $idToken"
-            val token = authApiService.fetchLoginToken(header)
-            PayKidsPreference.getInstance().edit {
-                putString(ACCESS_TOKEN, token.data.accessToken)
-                putString(REFRESH_TOKEN, token.data.refreshToken)
+            val token = kakaoLoginService.login()
+            val response = authApiService.fetchLoginToken(token.idToken)
+            withContext(Dispatchers.IO) {
+                PayKidsPreference.getInstance().edit {
+                    putString(ACCESS_TOKEN, response.data.accessToken)
+                    putString(REFRESH_TOKEN, response.data.refreshToken)
+                }
             }
         }.fold(
             onSuccess = { DataResourceResult.Success(Unit) },
+            onFailure = { DataResourceResult.Failure(it) }
+        )
+    }
+
+    suspend fun logout(): DataResourceResult<Boolean> {
+        val result = kakaoLoginService.logout()
+        return result.fold(
+            onSuccess = { DataResourceResult.Success(true) },
             onFailure = { DataResourceResult.Failure(it) }
         )
     }

--- a/data/src/main/java/com/paykidscompose/data/util/Extensions.kt
+++ b/data/src/main/java/com/paykidscompose/data/util/Extensions.kt
@@ -1,0 +1,19 @@
+package com.paykidscompose.data.util
+
+import android.content.Intent
+import android.os.Bundle
+
+
+fun <T> Intent.getCustomParcelableExtra(name: String, clazz: Class<T>): T? {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+        return getParcelableExtra(name, clazz)
+    }
+    return getParcelableExtra(name)
+}
+
+fun <T> Bundle.getCustomParcelableExtra(name: String, clazz: Class<T>): T? {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+        return getParcelable(name, clazz)
+    }
+    return getParcelable(name)
+}


### PR DESCRIPTION
## 📝작업 내용

> 카카오 로그인 로그아웃 구현했습니다.

## 작업 상세 내용

- [x] 카카오 액티비티 구현
- [x] 카카오 서비스 구현
- [x] 메인액티비티에서 테스트 했습니다.

### 💬리뷰 요구사항(선택)

> 다음 주 월요일 까지 따로 카카오 로그인 테스트는 하지 말아주세요. 각 버튼들을 누르면 로그인, 로그아웃이 실행되도록 구현하겠습니다.