### PR TITLE
refactor: QuizMapper QuizType 매핑

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,16 +35,19 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "21"
     }
     buildFeatures {
         compose = true
         viewBinding = true
         buildConfig = true
+    }
+    kotlin {
+        jvmToolchain(21)
     }
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,12 +3,12 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.jvm)
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
     }
 }
 

--- a/common/src/main/java/com/paykidscompose/common/enums/QuizClearType.kt
+++ b/common/src/main/java/com/paykidscompose/common/enums/QuizClearType.kt
@@ -1,4 +1,4 @@
-package com.paykidscompose.presentation.model.type
+package com.paykidscompose.common.enums
 
 enum class QuizClearType {
     ALL_CLEAR,

--- a/common/src/main/java/com/paykidscompose/common/enums/QuizType.kt
+++ b/common/src/main/java/com/paykidscompose/common/enums/QuizType.kt
@@ -1,0 +1,5 @@
+package com.paykidscompose.common.enums
+
+enum class QuizType {
+    IMAGE_CHOICE, TEXT_CHOICE, TEXT_CHOICE_IMAGE, SHORT_ANSWER, SHORT_ANSWER_IMAGE
+}

--- a/common/src/main/java/com/paykidscompose/common/model/QuizModel.kt
+++ b/common/src/main/java/com/paykidscompose/common/model/QuizModel.kt
@@ -1,11 +1,13 @@
 package com.paykidscompose.common.model
 
+import com.paykidscompose.common.enums.QuizType
+
 data class QuizModel (
     val id: Long,
     val stage: Int,
     val number: Int,
     val count: Int,
-    val quizType: String,
+    val quizType: QuizType,
     val question: String,
     val choices: Map<String, String>,
     val answer: String,

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -31,14 +31,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "21"
     }
     buildFeatures {
         buildConfig = true
+    }
+    kotlin {
+        jvmToolchain(21)
     }
 }
 

--- a/data/src/main/java/com/paykidscompose/data/mapper/quiz/QuizMapper.kt
+++ b/data/src/main/java/com/paykidscompose/data/mapper/quiz/QuizMapper.kt
@@ -1,17 +1,35 @@
 package com.paykidscompose.data.mapper.quiz
 
+import com.paykidscompose.common.enums.QuizType
 import com.paykidscompose.common.mapper.ModelMapper
 import com.paykidscompose.common.model.QuizModel
 import com.paykidscompose.data.model.quiz.QuizDTO
 
 object QuizMapper : ModelMapper<QuizModel, QuizDTO> {
     override fun mapToModel(layerModel: QuizDTO): QuizModel {
+        val baseQuizType = when (layerModel.quizType) {
+            QuizType.TEXT_CHOICE.name -> QuizType.TEXT_CHOICE
+            QuizType.IMAGE_CHOICE.name -> QuizType.IMAGE_CHOICE
+            QuizType.SHORT_ANSWER.name -> QuizType.SHORT_ANSWER
+            else -> throw IllegalArgumentException("Invalid quizType: ${layerModel.quizType}")
+        }
+
+        val finalQuizType = when (baseQuizType) {
+            QuizType.TEXT_CHOICE -> {
+                if (layerModel.imageURL.isNotEmpty()) QuizType.TEXT_CHOICE_IMAGE else baseQuizType
+            }
+            QuizType.SHORT_ANSWER -> {
+                if (layerModel.imageURL.isNotEmpty()) QuizType.SHORT_ANSWER_IMAGE else baseQuizType
+            }
+            else -> baseQuizType // IMAGE_CHOICE는 확장 없음
+        }
+
         return QuizModel(
             id = layerModel.id,
             stage = layerModel.stage,
             number = layerModel.number,
             count = layerModel.count,
-            quizType = layerModel.quizType,
+            quizType = finalQuizType,
             question = layerModel.question,
             choices = layerModel.choices,
             answer = layerModel.answer,
@@ -20,12 +38,18 @@ object QuizMapper : ModelMapper<QuizModel, QuizDTO> {
     }
 
     override fun mapToLayerModel(model: QuizModel): QuizDTO {
+        val baseQuizType = when (model.quizType) {
+            QuizType.TEXT_CHOICE, QuizType.TEXT_CHOICE_IMAGE -> QuizType.TEXT_CHOICE.name
+            QuizType.IMAGE_CHOICE -> QuizType.IMAGE_CHOICE.name
+            QuizType.SHORT_ANSWER, QuizType.SHORT_ANSWER_IMAGE -> QuizType.SHORT_ANSWER.name
+        }
+
         return QuizDTO(
             id = model.id,
             stage = model.stage,
             number = model.number,
             count = model.count,
-            quizType = model.quizType,
+            quizType = baseQuizType,
             question = model.question,
             choices = model.choices,
             answer = model.answer,

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -30,11 +30,14 @@ android {
         compose = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "21"
+    }
+    kotlin {
+        jvmToolchain(21)
     }
 }
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/dummy/DummyQuiz.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/dummy/DummyQuiz.kt
@@ -1,6 +1,6 @@
 package com.paykidscompose.presentation.dummy
 
-import com.paykidscompose.presentation.model.type.QuizType
+import com.paykidscompose.common.enums.QuizType
 
 data class Quiz(
     val id: Int,
@@ -48,7 +48,7 @@ object DummyQuiz {
             id = 3,
             stage = 1,
             number = 3,
-            quizType = QuizType.IMAGE,
+            quizType = QuizType.IMAGE_CHOICE,
             question = "다음 중 지폐는 무엇일까요?",
             choices = listOf(
                 "지갑",

--- a/presentation/src/main/java/com/paykidscompose/presentation/mapper/quiz/QuizUIModelMapper.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/mapper/quiz/QuizUIModelMapper.kt
@@ -3,7 +3,6 @@ package com.paykidscompose.presentation.mapper.quiz
 import com.paykidscompose.common.mapper.ModelMapper
 import com.paykidscompose.common.model.QuizModel
 import com.paykidscompose.presentation.model.QuizUIModel
-import com.paykidscompose.presentation.model.type.QuizType
 
 object QuizUIModelMapper: ModelMapper<QuizModel, QuizUIModel> {
     override fun mapToModel(layerModel: QuizUIModel): QuizModel {
@@ -14,7 +13,7 @@ object QuizUIModelMapper: ModelMapper<QuizModel, QuizUIModel> {
         return QuizUIModel(
             stage = model.stage,
             number = model.number,
-            quizType = QuizType.valueOf(model.quizType),
+            quizType = model.quizType,
             question = model.question,
             choices = model.choices.toSortedMap().values.toList(),
             answer = model.answer,

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/QuizClearConfigUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/QuizClearConfigUIModel.kt
@@ -3,7 +3,7 @@ package com.paykidscompose.presentation.model
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.model.type.QuizClearType
+import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.presentation.ui.theme.Gray10
 import com.paykidscompose.presentation.ui.theme.Gray8
 import com.paykidscompose.presentation.ui.theme.Purple

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/QuizUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/QuizUIModel.kt
@@ -1,8 +1,6 @@
 package com.paykidscompose.presentation.model
 
-import com.paykidscompose.common.exception.PayKidsException
-import com.paykidscompose.presentation.base.UIState
-import com.paykidscompose.presentation.model.type.QuizType
+import com.paykidscompose.common.enums.QuizType
 
 data class QuizUIModel(
     val stage: Int,
@@ -14,14 +12,3 @@ data class QuizUIModel(
     val imageUrl: List<String>?,
     val totalCount: Int = 0
 ): UIModel()
-
-data class QuizUIState(
-    override val isLoading: Boolean = false,
-    override val error: PayKidsException? = null,
-    val quizzes: MutableList<QuizUIModel> = mutableListOf(),
-    val totalCount: Int = 0,
-    val currentIndex: Int = 0,
-): UIState() {
-    val currentQuiz: QuizUIModel?
-        get() = quizzes.getOrNull(currentIndex)
-}

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/type/QuizType.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/type/QuizType.kt
@@ -1,5 +1,0 @@
-package com.paykidscompose.presentation.model.type
-
-enum class QuizType {
-    IMAGE, TEXT_CHOICE, TEXT_CHOICE_IMAGE, SHORT_ANSWER, SHORT_ANSWER_IMAGE
-}

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/route/QuizNavigationRoute.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/route/QuizNavigationRoute.kt
@@ -1,6 +1,6 @@
 package com.paykidscompose.presentation.navigation.route
 
-import com.paykidscompose.presentation.model.type.QuizClearType
+import com.paykidscompose.common.enums.QuizClearType
 import kotlinx.serialization.Serializable
 
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/ExpenseAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/ExpenseAnalysisScreen.kt
@@ -39,10 +39,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.paykidscompose.common.enums.AllowanceType
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.dummy.AllowanceChartDTO

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizClearScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizClearScreen.kt
@@ -15,7 +15,7 @@ import coil3.compose.AsyncImage
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.QuizClearConfigUIModel
 import com.paykidscompose.presentation.model.toConfig
-import com.paykidscompose.presentation.model.type.QuizClearType
+import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.presentation.ui.components.DashedCard
 import com.paykidscompose.presentation.ui.components.DecisionButton
 import com.paykidscompose.presentation.ui.theme.Black

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -26,11 +26,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
+import com.paykidscompose.common.enums.QuizType
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.QuizUIModel
-import com.paykidscompose.presentation.model.type.QuizClearType
+import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.presentation.model.type.QuizResultType
-import com.paykidscompose.presentation.model.type.QuizType
 import com.paykidscompose.presentation.screens.quiz.section.ImageQuizContent
 import com.paykidscompose.presentation.screens.quiz.section.QuizTopBar
 import com.paykidscompose.presentation.screens.quiz.section.ShortAnswerQuizContent
@@ -194,7 +194,7 @@ fun QuizScreen(
                 }
 
                 when (currentQuiz.quizType) {
-                    QuizType.IMAGE -> {
+                    QuizType.IMAGE_CHOICE -> {
                         val imageChoices = currentQuiz.imageUrl?.mapIndexed { index, imageUrl ->
                             val label = currentQuiz.choices?.getOrNull(index)?: ""
                             imageUrl to label

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,12 +23,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
+import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.common.enums.QuizType
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.QuizUIModel
-import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.presentation.model.type.QuizResultType
 import com.paykidscompose.presentation.screens.quiz.section.ImageQuizContent
 import com.paykidscompose.presentation.screens.quiz.section.QuizTopBar
@@ -63,7 +63,7 @@ fun Quiz(
     var isCorrect by remember { mutableStateOf(QuizResultType.DEFAULT) }
     var userInput by remember { mutableStateOf("") }
 
-    val uiState by quizViewModel.uiState.collectAsState()
+    val uiState by quizViewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         quizViewModel.loadQuiz(stageNumber)

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizViewModel.kt
@@ -3,9 +3,9 @@ package com.paykidscompose.presentation.screens.quiz
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.presentation.base.UIState
 import com.paykidscompose.presentation.dummy.DummyQuiz
 import com.paykidscompose.presentation.model.QuizUIModel
-import com.paykidscompose.presentation.model.QuizUIState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -71,4 +71,15 @@ class QuizViewModel : ViewModel() {
     fun isLastQuiz(): Boolean {
         return uiState.value.currentIndex == uiState.value.quizzes.lastIndex
     }
+}
+
+data class QuizUIState(
+    override val isLoading: Boolean = false,
+    override val error: PayKidsException? = null,
+    val quizzes: MutableList<QuizUIModel> = mutableListOf(),
+    val totalCount: Int = 0,
+    val currentIndex: Int = 0,
+): UIState() {
+    val currentQuiz: QuizUIModel?
+        get() = quizzes.getOrNull(currentIndex)
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/section/ShortAnswerQuizContent.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/section/ShortAnswerQuizContent.kt
@@ -13,8 +13,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.paykidscompose.common.enums.QuizType
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.model.type.QuizType
 import com.paykidscompose.presentation.ui.components.DecisionButton
 import com.paykidscompose.presentation.ui.components.OutlineInputField
 import com.paykidscompose.presentation.ui.theme.Blue2

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/TextComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/TextComponents.kt
@@ -34,7 +34,6 @@ import com.paykidscompose.presentation.ui.theme.NicknameScreenFieldBoxHeight
 import com.paykidscompose.presentation.ui.theme.NicknameTitleTextStyle
 import com.paykidscompose.presentation.ui.theme.OutlineBorder
 import com.paykidscompose.presentation.ui.theme.OutlineDefaultShadowElevation
-import com.paykidscompose.presentation.ui.theme.OutlineDefaultShadowRound
 import com.paykidscompose.presentation.ui.theme.OutlineShape
 import com.paykidscompose.presentation.ui.theme.TitleColor
 import com.paykidscompose.presentation.ui.theme.White

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -217,7 +217,6 @@ val OutlineBorder = 1.dp
 val OutlineShape = 10.dp
 val OutlineHeight = 40.dp
 val OutlineDefaultShadowElevation = 0.dp
-val OutlineDefaultShadowRound = 20.dp
 val ShortAnswerQuizOutlineHeight = 86.dp
 val ShortAnswerQuizOutlineStartPadding = 91.dp
 val ShortAnswerQuizOutlineShape = 20.dp


### PR DESCRIPTION
## 📝작업 내용

> QuizMapper QuizType 매핑 개선

## 작업 상세 내용

- [x] QuizType, QuizClearType 위치 common 모듈 enums 패키지로 이동
- [x] String이던 quizType을 QuizUIModel(presentation)로 변환할 때가 아닌, QuizModel(common)로 변환할 때 enum class인 QuizType으로 매핑
- [x] QuizUIState 파일 위치 QuizViewModel 안으로 이동
- [x] import문 정리, Dimens 정리
- [x] gradle JavaVersion 21로 변경
- [x] QuizScreen collectAsStateWithLifecycle로 변경

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 
