### PR TITLE
feat: 마이페이지 화면

### DIFF
--- a/common/src/main/java/com/paykidscompose/common/enums/ExceptionType.kt
+++ b/common/src/main/java/com/paykidscompose/common/enums/ExceptionType.kt
@@ -1,7 +1,18 @@
 package com.paykidscompose.common.enums
 
+/**
+ * 화면의 에러 즉 로드할 때 에러가 발생하면 스낵바랑 토스트보다 다이얼로그를 띄우기
+ * 그 외에 저장 변경 삭제 등은 다이얼로그가 아닌 스낵바와 토스트를 사용하기.
+ */
+
 sealed interface ExceptionType {
     object Snack: ExceptionType
 
     object Toast: ExceptionType
+
+    object Dialog: ExceptionType
+}
+
+enum class ActionType {
+    RETRY_API
 }

--- a/common/src/main/java/com/paykidscompose/common/exception/PayKidsException.kt
+++ b/common/src/main/java/com/paykidscompose/common/exception/PayKidsException.kt
@@ -1,6 +1,7 @@
 package com.paykidscompose.common.exception
 
 import com.paykidscompose.common.enums.ExceptionType
+import com.paykidscompose.common.model.Dialog
 
 sealed class PayKidsException(
     open val code: Int,
@@ -18,4 +19,8 @@ sealed class PayKidsException(
         override val message: String
     ) : PayKidsException(code, ExceptionType.Toast, message)
 
+    data class DialogException(
+        override val code: Int,
+        val dialog: Dialog
+    ) : PayKidsException(code, ExceptionType.Dialog, null)
 }

--- a/common/src/main/java/com/paykidscompose/common/model/Dialog.kt
+++ b/common/src/main/java/com/paykidscompose/common/model/Dialog.kt
@@ -1,0 +1,14 @@
+package com.paykidscompose.common.model
+
+import com.paykidscompose.common.enums.ActionType
+
+data class Dialog(
+    val title: String,
+    val message: String,
+    val positiveMessage: String? = null,
+    val positiveAction: ActionType? = null,
+    val positiveObject: Any? = null,
+    val negativeMessage: String? = null,
+    val negativeAction: ActionType? = null,
+    val negativeObject: Any? = null
+)

--- a/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
@@ -4,6 +4,7 @@ import androidx.core.content.edit
 import com.paykidscompose.common.repositories.AuthRepository
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.data.database.PayKidsPreference
+import com.paykidscompose.data.model.AuthStatusManagerImpl
 import com.paykidscompose.data.network.service.AuthApiService
 import com.paykidscompose.data.network.service.authentication.KakaoLoginService
 import com.paykidscompose.data.util.ACCESS_TOKEN
@@ -51,6 +52,9 @@ class AuthRepositoryImpl(
                     remove(REFRESH_TOKEN)
                     remove(USER_REGISTERED)
                 }
+
+//                AuthStatusManagerImpl.notifyLoginScreenNav()
+
                 DataResourceResult.Success(Unit)
             },
             onFailure = { DataResourceResult.Failure(it) }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/MyPageScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
+import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.MyPageUIModel
 import com.paykidscompose.presentation.screens.mypage.section.MyPageTopBar
@@ -27,7 +29,6 @@ import com.paykidscompose.presentation.ui.components.CardItem
 import com.paykidscompose.presentation.ui.components.CustomCard
 import com.paykidscompose.presentation.ui.components.CustomDivider
 import com.paykidscompose.presentation.ui.components.PopupDialog
-import com.paykidscompose.presentation.ui.components.ScreenError
 import com.paykidscompose.presentation.ui.components.ScreenLoading
 import com.paykidscompose.presentation.ui.components.TitleText
 import com.paykidscompose.presentation.ui.components.util.PopupType
@@ -50,6 +51,8 @@ fun MyPage(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
+    val context = LocalContext.current
+
     if (uiState.showLogoutDialog) {
         PopupDialog(
             title = stringResource(R.string.dialog_signout_title),
@@ -60,19 +63,31 @@ fun MyPage(
         )
     }
 
-    LaunchedEffect(true) {
+    LaunchedEffect(Unit) {
         viewModel.load()
+    }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            when (it) {
+                is PayKidsException.SnackBarException -> {
+
+                }
+
+                is PayKidsException.DialogException -> {
+
+                }
+
+                is PayKidsException.ToastException -> {
+
+                }
+            }
+        }
     }
 
     when {
         uiState.isLoading -> {
             ScreenLoading()
-        }
-
-        uiState.error != null -> {
-            ScreenError {
-                viewModel.load()
-            }
         }
 
         uiState.myPage != null -> {


### PR DESCRIPTION
데이터 로드 과정 중에서 에러가 발생하면 화면을 보여주기 보다 다이얼로그를 띄워야해서 모델와 Exception에 추가했습니다

또한 로그아웃을 누르면 로그인 화면으로 가지 않아서 수정할 예정입니다.

## 📝작업 내용

> 데이터 로드 과정 중에서 에러가 발생하면 화면을 보여주기 보다 다이얼로그를 띄워야해서 모델와 Exception에 추가했습니다
> 또한 로그아웃을 누르면 로그인 화면으로 가지 않아서 수정할 예정입니다.