### PR TITLE
feat: Home -> QuizEntry 스테이지 이름 전달

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
                     provider.getUserUseCase,
                     provider.deleteUserUseCase,
                     provider.logoutUseCase,
-                    provider.replaceNicknameUseCase
+                    provider.replaceNicknameUseCase,
 
                     provider.getStageCountUseCase,
                     provider.getStageToGoUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -64,7 +64,7 @@ fun PayKidsApp(
     getUserUseCase: GetUserUseCase,
     deleteUserUseCase: DeleteUserUseCase,
     logoutUseCase: LogoutUseCase,
-    replaceNicknameUseCase: ReplaceNicknameUseCase
+    replaceNicknameUseCase: ReplaceNicknameUseCase,
     getStageCountUseCase: GetStageCountUseCase,
     getStageToGoUseCase: GetStageToGoUseCase,
     getStageNameUseCase: GetStageNameUseCase
@@ -131,9 +131,9 @@ fun PayKidsApp(
                     viewModelStoreOwner = it,
                     factory = HomeViewModelFactory(getStageCountUseCase, getStageToGoUseCase, getStageNameUseCase)
                 )
-                Home(viewModel) { stageNumber ->
+                Home(viewModel) { stageNumber, stageTitle ->
                     navController.navigate(
-                        QuizNavigationRoute.QuizEntryRoute(stageNumber)
+                        QuizNavigationRoute.QuizEntryRoute(stageNumber, stageTitle)
                     )
                 }
             }
@@ -141,9 +141,11 @@ fun PayKidsApp(
             composable<QuizNavigationRoute.QuizEntryRoute> { backStack ->
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.QuizEntryRoute>()
                 val stageNumber = targetRoute.stageNumber
+                val stageTitle = targetRoute.stageTitle
 
                 QuizEntry(
                     stageNumber = stageNumber,
+                    stageTitle = stageTitle,
                     onQuiz = {
                         navController.navigate(QuizNavigationRoute.QuizRoute(stageNumber))
                     },

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/route/QuizNavigationRoute.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/route/QuizNavigationRoute.kt
@@ -10,7 +10,7 @@ sealed interface QuizNavigationRoute: NavigationRoute {
     data class QuizRoute(val stageNumber: Int): QuizNavigationRoute
 
     @Serializable
-    data class QuizEntryRoute(val stageNumber: Int): QuizNavigationRoute
+    data class QuizEntryRoute(val stageNumber: Int, val stageTitle: String): QuizNavigationRoute
 
     @Serializable
     data class QuizClearRoute(val clear: QuizClearType): QuizNavigationRoute

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeScreen.kt
@@ -85,7 +85,7 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun Home(
     homeViewModel: HomeViewModel = viewModel(),
-    onStageNumber: (Int) -> Unit = {}
+    onNavigateToQuiz: (Int, String) -> Unit = { _, _ -> }
 ) {
     val uiState by homeViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -93,29 +93,14 @@ fun Home(
         homeViewModel.loadAllData()
     }
 
-//    val selectedStageIndex = rememberSaveable {
-//        mutableIntStateOf(-1)
-//    }
-//
-//    LaunchedEffect(uiState.unlockedStageNumber) {
-//        if (uiState.unlockedStageNumber > 0 && selectedStageIndex.intValue == -1) {
-//            selectedStageIndex.intValue = uiState.unlockedStageNumber - 1
-//        }
-//    } // 마지막 클리어 스테이지
-
     val tooltipOffset = remember { mutableStateOf<Offset?>(null) }
 
     HomeScreen(
-//        selectedStageIndex = selectedStageIndex.intValue,
-//        onStageSelected = {
-//            selectedStageIndex.intValue = it
-//            homeViewModel.loadStageTitle(it + 1)
-//        },
         selectedStageIndex = uiState.selectedStageIndex,
         onStageSelected = homeViewModel::onStageSelected,
         tooltipOffset = tooltipOffset.value,
         onTooltipOffsetChange = { tooltipOffset.value = it },
-        onStageNumber = onStageNumber,
+        onNavigateToQuiz = onNavigateToQuiz,
         totalStageCount = uiState.totalStageCount,
         unlockedStageCount = uiState.unlockedStageNumber,
         stageTitle = uiState.stageTitle
@@ -131,7 +116,7 @@ fun HomeScreen(
     onStageSelected: (Int) -> Unit,
     tooltipOffset: Offset?,
     onTooltipOffsetChange: (Offset?) -> Unit,
-    onStageNumber: (Int) -> Unit = {}
+    onNavigateToQuiz: (Int, String) -> Unit = { _, _ -> }
 ) {
     val scrollState = rememberLazyListState()
     val density = LocalDensity.current
@@ -311,7 +296,7 @@ fun HomeScreen(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() }
                     ) {
-                        onStageNumber(selectedStageIndex + 1)
+                        onNavigateToQuiz(selectedStageIndex + 1, stageTitle)
                     }
             )
         }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/home/HomeViewModel.kt
@@ -48,7 +48,7 @@ class HomeViewModel(
 
                 is DataResourceResult.Failure -> {
                     _uiState.update {
-                        it.copy(error = PayKidsException.SnackBarException(message = ""))
+                        it.copy(error = result.exception)
                     }
                     Log.d(TAG, "error: ${result.exception.message}")
                 }
@@ -76,7 +76,7 @@ class HomeViewModel(
 
                 is DataResourceResult.Failure -> {
                     _uiState.update {
-                        it.copy(error = PayKidsException.SnackBarException(message = ""))
+                        it.copy(error = result.exception)
                     }
                     Log.d(TAG, "error: ${result.exception.message}")
                 }
@@ -103,7 +103,7 @@ class HomeViewModel(
 
                 is DataResourceResult.Failure -> {
                     _uiState.update {
-                        it.copy(error = PayKidsException.SnackBarException(message = ""))
+                        it.copy(error = result.exception)
                     }
                     Log.d(TAG, "error: ${result.exception.message}")
                 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/info/MyInfoScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/info/MyInfoScreen.kt
@@ -122,6 +122,8 @@ fun MyInfo(
 
                 is PayKidsException.SnackBarException -> {
                 }
+
+                is PayKidsException.DialogException -> TODO()
             }
 
             viewModel.clearError()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizEntryScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import coil3.compose.AsyncImage
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.dummy.getStageTitle
 import com.paykidscompose.presentation.ui.components.DecisionButton
 import com.paykidscompose.presentation.ui.components.PopupDialog
 import com.paykidscompose.presentation.ui.components.util.PopupType
@@ -57,6 +56,7 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun QuizEntry(
     stageNumber: Int,
+    stageTitle: String,
     onShowDialogChange: (Boolean) -> Unit = {},
     onQuiz: (Int) -> Unit = {},
     onStudyClick: () -> Unit = {},
@@ -66,6 +66,7 @@ fun QuizEntry(
 
     QuizEntryScreen(
         stageNumber = stageNumber,
+        stageTitle = stageTitle,
         showDialog = showDialog,
         onShowDialogChange = onShowDialogChange,
         onQuiz = onQuiz,
@@ -77,13 +78,14 @@ fun QuizEntry(
 @Composable
 fun QuizEntryScreen(
     stageNumber: Int,
+    stageTitle: String,
     showDialog: Boolean,
     onShowDialogChange: (Boolean) -> Unit,
     onQuiz: (Int) -> Unit = {},
     onStudyClick: () -> Unit = {},
     onBackClick: () -> Unit = {}
 ) {
-    val stageTitle = getStageTitle(stageNumber - 1)
+    //val stageTitle = getStageTitle(stageNumber - 1)
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -193,6 +195,6 @@ fun QuizEntryScreen(
 @Composable
 fun QuizEntryScreenPreview() {
     PayKidsComposeTheme {
-        QuizEntry(2)
+        QuizEntry(2, "은행은 어떤 곳인가요?")
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 홈 화면에서 퀴즈 진입화면으로 이동할 때 스테이지 이름 전달 구현

## 작업 상세 내용

- [x] 이전 PR merge 하면서 발생한 코드 오류 수정
- [x] HomeViewModel error 코드 result.exception으로 수정
- [x] Home -> QuizEntry 이동 시 스테이지 이름 인자로 전달

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

>