### PR TITLE
feat: 마이페이지 화면

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -40,7 +40,6 @@ class MainActivity : ComponentActivity() {
                     provider.deleteUserUseCase,
                     provider.logoutUseCase,
                     provider.replaceNicknameUseCase,
-
                     provider.getStageCountUseCase,
                     provider.getStageToGoUseCase,
                     provider.getStageNameUseCase

--- a/data/src/main/java/com/paykidscompose/data/model/AuthStatusManagerImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/model/AuthStatusManagerImpl.kt
@@ -54,4 +54,9 @@ object AuthStatusManagerImpl : AuthStatusManager() {
             job.cancel()
         }
     }
+
+    fun notifyLoginScreenNav() {
+        registeredFlow.tryEmit(false)
+        tokenFlow.tryEmit("")
+    }
 }

--- a/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/AuthRepositoryImpl.kt
@@ -53,9 +53,7 @@ class AuthRepositoryImpl(
                     remove(REFRESH_TOKEN)
                     remove(USER_REGISTERED)
                 }
-
-//                AuthStatusManagerImpl.notifyLoginScreenNav()
-
+                AuthStatusManagerImpl.notifyLoginScreenNav()
                 DataResourceResult.Success(Unit)
             },
             onFailure = { DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = it.message ?: "")) }

--- a/data/src/main/java/com/paykidscompose/data/repositories/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/UserRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.paykidscompose.common.repositories.UserRepository
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.data.database.PayKidsPreference
 import com.paykidscompose.data.mapper.user.UserMapper
+import com.paykidscompose.data.model.AuthStatusManagerImpl
 import com.paykidscompose.data.network.service.UserApiService
 import com.paykidscompose.data.util.ACCESS_TOKEN
 import com.paykidscompose.data.util.REFRESH_TOKEN
@@ -28,9 +29,17 @@ class UserRepositoryImpl(
                     remove(REFRESH_TOKEN)
                     remove(USER_REGISTERED)
                 }
+                AuthStatusManagerImpl.notifyLoginScreenNav()
                 DataResourceResult.Success(it.data)
             },
-            onFailure = { DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = it.message ?: "회원탈퇴 과정 중 통신 에러 발생")) }
+            onFailure = {
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = it.message ?: "회원탈퇴 과정 중 통신 에러 발생"
+                    )
+                )
+            }
         )
     }
 
@@ -44,7 +53,14 @@ class UserRepositoryImpl(
                 }
                 DataResourceResult.Success(it.data)
             },
-            onFailure = { DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = it.message ?: "닉네임 저장 과정 중 통신 에러 발생")) }
+            onFailure = {
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = it.message ?: "닉네임 저장 과정 중 통신 에러 발생"
+                    )
+                )
+            }
         )
     }
 
@@ -53,7 +69,14 @@ class UserRepositoryImpl(
             userApiService.replaceNickname(newNickname)
         }.fold(
             onSuccess = { DataResourceResult.Success(it.data) },
-            onFailure = { DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = it.message ?: "닉네임 변경 과정 중 통신 에러 발생")) }
+            onFailure = {
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = it.message ?: "닉네임 변경 과정 중 통신 에러 발생"
+                    )
+                )
+            }
         )
     }
 
@@ -62,7 +85,14 @@ class UserRepositoryImpl(
             userApiService.replaceProfileImage(file)
         }.fold(
             onSuccess = { DataResourceResult.Success(it.data) },
-            onFailure = { DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = it.message ?: "프로필 변경 과정 중 통신 에러 발생")) }
+            onFailure = {
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = it.message ?: "프로필 변경 과정 중 통신 에러 발생"
+                    )
+                )
+            }
         )
     }
 
@@ -75,7 +105,16 @@ class UserRepositoryImpl(
                 val user = UserMapper.mapToModel(it.data)
                 emit(DataResourceResult.Success(user))
             },
-            onFailure = { emit(DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = it.message ?: "유저 로드 과정 중 통신 에러 발생"))) }
+            onFailure = {
+                emit(
+                    DataResourceResult.Failure(
+                        PayKidsException.ToastException(
+                            code = -1,
+                            message = it.message ?: "유저 로드 과정 중 통신 에러 발생"
+                        )
+                    )
+                )
+            }
         )
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/MyPageScreen.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.screens.mypage
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,10 +19,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.base.UIEvent
 import com.paykidscompose.presentation.model.MyPageUIModel
 import com.paykidscompose.presentation.screens.mypage.section.MyPageTopBar
 import com.paykidscompose.presentation.ui.components.CardItem
@@ -49,7 +51,7 @@ fun MyPage(
     onClickTerms: () -> Unit = {},
     onClickAppVersion: () -> Unit = {}
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
 
@@ -67,6 +69,16 @@ fun MyPage(
         viewModel.load()
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { event ->
+            when (event) {
+                is UIEvent.SuccessShowToast -> {
+                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
     LaunchedEffect(uiState.error) {
         uiState.error?.let {
             when (it) {
@@ -75,13 +87,14 @@ fun MyPage(
                 }
 
                 is PayKidsException.DialogException -> {
-
                 }
 
                 is PayKidsException.ToastException -> {
-
+                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
                 }
             }
+
+            viewModel.clearError()
         }
     }
 
@@ -98,7 +111,6 @@ fun MyPage(
                 onClickAppVersion = onClickAppVersion,
                 onLogoutClick = { viewModel.onLogoutClick() }
             )
-
         }
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/MyPageViewModel.kt
@@ -6,10 +6,13 @@ import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
+import com.paykidscompose.presentation.base.UIEvent
 import com.paykidscompose.presentation.base.UIState
 import com.paykidscompose.presentation.model.MyPageUIModel
 import com.paykidscompose.presentation.model.MyPageUIModelMapper
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
@@ -21,6 +24,9 @@ class MyPageViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(MyPageUIState())
     val uiState = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<UIEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
 
     fun load() {
         if (_uiState.value.isLoading) return
@@ -47,15 +53,14 @@ class MyPageViewModel(
                                 error = null
                             )
                         }
+                        _uiEvent.emit(UIEvent.SuccessShowToast("유저 정보를 정상적으로 가져왔습니다."))
                     }
 
                     is DataResourceResult.Failure -> {
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
-                                error = PayKidsException.SnackBarException(
-                                    message = result.exception.message ?: "유저 정보를 불러오지 못했습니다."
-                                )
+                                error = result.exception
                             )
                         }
                     }
@@ -85,14 +90,13 @@ class MyPageViewModel(
                     _uiState.update {
                         it.copy(isLogoutSuccess = true)
                     }
+                    _uiEvent.emit(UIEvent.SuccessShowToast("로그아웃 되었습니다!"))
                 }
 
                 is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
-                            error = PayKidsException.SnackBarException(
-                                message = result.exception.message ?: "로그아웃 과정에 오류가 발생했습니다."
-                            )
+                            error = result.exception
                         )
                     }
                 }
@@ -102,6 +106,11 @@ class MyPageViewModel(
         }
     }
 
+    fun clearError() {
+        _uiState.update {
+            it.copy(error = null)
+        }
+    }
 }
 
 data class MyPageUIState(

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/info/MyInfoScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/mypage/info/MyInfoScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.paykidscompose.common.exception.PayKidsException
@@ -82,7 +82,7 @@ fun MyInfo(
     viewModel: MyInfoViewModel = viewModel(),
     onBackClick: () -> Unit = {}
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     if (uiState.showPopupDialog) {
@@ -123,7 +123,8 @@ fun MyInfo(
                 is PayKidsException.SnackBarException -> {
                 }
 
-                is PayKidsException.DialogException -> TODO()
+                is PayKidsException.DialogException -> {
+                }
             }
 
             viewModel.clearError()


### PR DESCRIPTION
## 📝작업 내용

> 로그아웃, 회원탈퇴를 하면 로그인 화면으로 이동 하게 했습니다.
> 성공이나 에러 발생하면 토스트를 띄워주도록 했습니다.

## 작업 상세 내용

- [x] 마이페이지 뷰모델, 컴포저블 수정
- [x] 성공, 에러 메시지를 사용자에게 보여주도록 구현
- [x] 로그아웃, 회원탈퇴를 하면 로그인 화면으로 이동

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
