### PR TITLE
feat: 퀴즈 화면과 퀴즈 뷰모델 함수 연결 및 의존성 수동 주입

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -42,7 +42,10 @@ class MainActivity : ComponentActivity() {
                     provider.replaceNicknameUseCase,
                     provider.getStageCountUseCase,
                     provider.getStageToGoUseCase,
-                    provider.getStageNameUseCase
+                    provider.getStageNameUseCase,
+                    provider.getAllQuizzesUseCase,
+                    provider.getCheckAnswerUseCase,
+                    provider.getCheckStageUseCase
                 )
             }
         }

--- a/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
+++ b/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import com.paykidscompose.common.di.ApplicationContainer
 import com.paykidscompose.common.usecase.authentication.LoginUseCase
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
+import com.paykidscompose.common.usecase.quiz.GetAllQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckAnswerUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckStageUseCase
+import com.paykidscompose.common.usecase.quiz.GetQuizUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageCountUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
@@ -44,4 +48,9 @@ class ApplicationContainerImpl(
     override val getStageCountUseCase: GetStageCountUseCase = GetStageCountUseCase(quizRepository)
     override val getStageToGoUseCase: GetStageToGoUseCase = GetStageToGoUseCase(quizRepository)
     override val getStageNameUseCase: GetStageNameUseCase = GetStageNameUseCase(quizRepository)
+
+    override val getQuizUseCase: GetQuizUseCase = GetQuizUseCase(quizRepository)
+    override val getAllQuizzesUseCase: GetAllQuizzesUseCase = GetAllQuizzesUseCase(getQuizUseCase)
+    override val getCheckAnswerUseCase: GetCheckAnswerUseCase = GetCheckAnswerUseCase(quizRepository)
+    override val getCheckStageUseCase: GetCheckStageUseCase = GetCheckStageUseCase(quizRepository)
 }

--- a/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
+++ b/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
@@ -2,6 +2,10 @@ package com.paykidscompose.common.di
 
 import com.paykidscompose.common.usecase.authentication.LoginUseCase
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
+import com.paykidscompose.common.usecase.quiz.GetAllQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckAnswerUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckStageUseCase
+import com.paykidscompose.common.usecase.quiz.GetQuizUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageCountUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
@@ -20,4 +24,8 @@ interface ApplicationContainer {
     val getStageCountUseCase: GetStageCountUseCase
     val getStageToGoUseCase: GetStageToGoUseCase
     val getStageNameUseCase: GetStageNameUseCase
+    val getQuizUseCase: GetQuizUseCase
+    val getAllQuizzesUseCase: GetAllQuizzesUseCase
+    val getCheckAnswerUseCase: GetCheckAnswerUseCase
+    val getCheckStageUseCase: GetCheckStageUseCase
 }

--- a/common/src/main/java/com/paykidscompose/common/usecase/quiz/GetAllQuizzesUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/quiz/GetAllQuizzesUseCase.kt
@@ -1,0 +1,75 @@
+package com.paykidscompose.common.usecase.quiz
+
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.model.QuizModel
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.base.FlowUseCase
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+
+class GetAllQuizzesUseCase(
+    private val getQuizUseCase: GetQuizUseCase
+) : FlowUseCase<GetAllQuizzesUseCase.Params, DataResourceResult<List<QuizModel>>>() {
+    override fun execute(params: Params?): Flow<DataResourceResult<List<QuizModel>>> {
+        if (params == null) {
+            return flowOf(DataResourceResult.Failure(PayKidsException.ToastException(code = -1, "")))
+        }
+
+        return flow {
+            runCatching {
+                coroutineScope {
+                    // 첫 번째 퀴즈 가져오기(퀴즈 데이터에 전체 퀴즈 개수가 포함되어 있기 때문에 첫 번째 퀴즈 먼저 로드)
+                    val firstResult = getQuizUseCase(
+                        GetQuizUseCase.Params(
+                            params.stage,
+                            1
+                        )
+                    ).first { it is DataResourceResult.Success || it is DataResourceResult.Failure }
+                    val firstQuiz = (firstResult as? DataResourceResult.Success)?.data
+                        ?: throw PayKidsException.ToastException(code = -1, "퀴즈 데이터를 불러올 수 없습니다.")
+
+                    val totalCount = firstQuiz.count
+                    // 나머지 퀴즈 병렬로 가져오기
+                    val rest = (2..totalCount).map { number ->
+                        async {
+                            getQuizUseCase(
+                                GetQuizUseCase.Params(
+                                    params.stage,
+                                    number
+                                )
+                            ).first { it is DataResourceResult.Success || it is DataResourceResult.Failure }
+                        }
+                    }.awaitAll()
+                        .mapNotNull { result ->
+                            (result as? DataResourceResult.Success)?.data
+                        }
+
+                    listOf(firstQuiz) + rest
+                }
+            }.fold(
+                onSuccess = { allQuizzes ->
+                    emit(DataResourceResult.Success(allQuizzes))
+                },
+                onFailure = {
+                    emit(
+                        DataResourceResult.Failure(
+                            PayKidsException.ToastException(
+                                code = -1,
+                                "퀴즈 전체 로딩 실패"
+                            )
+                        )
+                    )
+                }
+            )
+        }
+    }
+
+    data class Params(
+        val stage: Int
+    )
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/QuizViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/QuizViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.paykidscompose.presentation.factory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.paykidscompose.common.usecase.quiz.GetAllQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckAnswerUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckStageUseCase
+import com.paykidscompose.presentation.screens.quiz.QuizViewModel
+
+class QuizViewModelFactory(
+    private val getAllQuizzesUseCase: GetAllQuizzesUseCase,
+    private val getCheckAnswerUseCase: GetCheckAnswerUseCase,
+    private val getCheckStageUseCase: GetCheckStageUseCase
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(QuizViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return QuizViewModel(getAllQuizzesUseCase, getCheckAnswerUseCase, getCheckStageUseCase) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/mapper/quiz/QuizUIModelMapper.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/mapper/quiz/QuizUIModelMapper.kt
@@ -17,7 +17,7 @@ object QuizUIModelMapper: ModelMapper<QuizModel, QuizUIModel> {
             question = model.question,
             choices = model.choices.toSortedMap().values.toList(),
             answer = model.answer,
-            imageUrl = model.choices.toSortedMap().values.toList(),
+            imageUrl = model.imageURL.toSortedMap().values.toList(),
             totalCount = model.count
         )
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -1,12 +1,9 @@
 package com.paykidscompose.presentation.navigation
 
 import android.util.Log
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,6 +19,9 @@ import androidx.navigation.toRoute
 import com.paykidscompose.common.enums.EntryPoint
 import com.paykidscompose.common.usecase.authentication.LoginUseCase
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
+import com.paykidscompose.common.usecase.quiz.GetAllQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckAnswerUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckStageUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageCountUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
@@ -34,6 +34,7 @@ import com.paykidscompose.presentation.factory.LoginNicknameViewModelFactory
 import com.paykidscompose.presentation.factory.LoginViewModelFactory
 import com.paykidscompose.presentation.factory.MyInfoViewModelFactory
 import com.paykidscompose.presentation.factory.MyPageViewModelFactory
+import com.paykidscompose.presentation.factory.QuizViewModelFactory
 import com.paykidscompose.presentation.navigation.route.AllowanceDiaryNavigationRoute
 import com.paykidscompose.presentation.navigation.route.EntryNavigationRoute
 import com.paykidscompose.presentation.navigation.route.MyPageNavigationRoute
@@ -58,6 +59,7 @@ import com.paykidscompose.presentation.screens.quest.QuestAndAchievement
 import com.paykidscompose.presentation.screens.quiz.Quiz
 import com.paykidscompose.presentation.screens.quiz.QuizClear
 import com.paykidscompose.presentation.screens.quiz.QuizEntry
+import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.study.Study
 import com.paykidscompose.presentation.ui.components.AppBottomBar
 
@@ -73,7 +75,10 @@ fun PayKidsApp(
     replaceNicknameUseCase: ReplaceNicknameUseCase,
     getStageCountUseCase: GetStageCountUseCase,
     getStageToGoUseCase: GetStageToGoUseCase,
-    getStageNameUseCase: GetStageNameUseCase
+    getStageNameUseCase: GetStageNameUseCase,
+    getAllQuizzesUseCase: GetAllQuizzesUseCase,
+    getCheckAnswerUseCase: GetCheckAnswerUseCase,
+    getCheckStageUseCase: GetCheckStageUseCase
 ) {
     val navController: NavHostController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -174,8 +179,18 @@ fun PayKidsApp(
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.QuizRoute>()
                 val stageNumber = targetRoute.stageNumber
 
+                val viewModel: QuizViewModel = viewModel(
+                    viewModelStoreOwner = backStack,
+                    factory = QuizViewModelFactory(
+                        getAllQuizzesUseCase,
+                        getCheckAnswerUseCase,
+                        getCheckStageUseCase
+                    )
+                )
+
                 Quiz(
                     stageNumber = stageNumber,
+                    quizViewModel = viewModel,
                     onBackClick = {
                         navController.popBackStack()
                     },

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizScreen.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.screens.quiz
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -28,6 +30,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.common.enums.QuizType
+import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.QuizUIModel
 import com.paykidscompose.presentation.model.type.QuizResultType
@@ -37,7 +40,6 @@ import com.paykidscompose.presentation.screens.quiz.section.ShortAnswerQuizConte
 import com.paykidscompose.presentation.screens.quiz.section.TextChoiceQuizContent
 import com.paykidscompose.presentation.ui.components.PopupDialog
 import com.paykidscompose.presentation.ui.components.QuizResultCard
-import com.paykidscompose.presentation.ui.components.ScreenError
 import com.paykidscompose.presentation.ui.components.ScreenLoading
 import com.paykidscompose.presentation.ui.components.util.PopupType
 import com.paykidscompose.presentation.ui.theme.Black
@@ -60,34 +62,49 @@ fun Quiz(
 ) {
     var showDialog by remember { mutableStateOf(false) }
     var selectedIndex by remember { mutableStateOf<Int?>(null) }
-    var isCorrect by remember { mutableStateOf(QuizResultType.DEFAULT) }
     var userInput by remember { mutableStateOf("") }
 
     val uiState by quizViewModel.uiState.collectAsStateWithLifecycle()
 
+    val context = LocalContext.current
+
     LaunchedEffect(Unit) {
-        quizViewModel.loadQuiz(stageNumber)
+        quizViewModel.loadQuizzes(stageNumber)
+    }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            when (it) {
+                is PayKidsException.SnackBarException -> {
+                }
+
+                is PayKidsException.DialogException -> {
+                }
+
+                is PayKidsException.ToastException -> {
+                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            quizViewModel.clearError()
+        }
     }
 
     when {
         uiState.isLoading -> {
             ScreenLoading()
         }
-        uiState.error != null -> {
-            ScreenError {
-                quizViewModel.loadQuiz(stageNumber)
-            }
-        }
+
         uiState.currentQuiz != null -> {
             QuizScreen(
+                quizViewModel = quizViewModel,
                 currentQuiz = uiState.currentQuiz!!,
                 isLastQuiz = quizViewModel.isLastQuiz(),
                 showDialog = showDialog,
                 onShowDialogChange = { showDialog = it },
                 selectedIndex = selectedIndex,
                 onSelectedIndexChange = { selectedIndex = it },
-                isCorrect = isCorrect,
-                onCorrectChange = { isCorrect = it },
+                isCorrect = uiState.quizResultType,
                 userInput = userInput,
                 onUserInputChange = { userInput = it },
                 quizNumber = uiState.currentIndex + 1,
@@ -102,6 +119,7 @@ fun Quiz(
 
 @Composable
 fun QuizScreen(
+    quizViewModel: QuizViewModel,
     currentQuiz: QuizUIModel,
     isLastQuiz: Boolean,
     showDialog: Boolean,
@@ -109,7 +127,6 @@ fun QuizScreen(
     selectedIndex: Int?,
     onSelectedIndexChange: (Int?) -> Unit,
     isCorrect: QuizResultType,
-    onCorrectChange: (QuizResultType) -> Unit,
     userInput: String,
     onUserInputChange: (String) -> Unit,
     quizNumber: Int,
@@ -139,11 +156,12 @@ fun QuizScreen(
         if (isCorrect != QuizResultType.DEFAULT) {
             delay(2000L)
             if (isLastQuiz) {
-                onConfirmClick(QuizClearType.ALL_CLEAR)
+                quizViewModel.checkClearStage { clearType ->
+                    onConfirmClick(clearType)
+                }
             } else {
                 onNextQuiz()
                 onSelectedIndexChange(null)
-                onCorrectChange(QuizResultType.DEFAULT)
                 onUserInputChange("")
             }
         }
@@ -183,7 +201,11 @@ fun QuizScreen(
                     textAlign = TextAlign.Center
                 )
 
-                if (currentQuiz.quizType !in listOf(QuizType.TEXT_CHOICE_IMAGE, QuizType.SHORT_ANSWER_IMAGE)) {
+                if (currentQuiz.quizType !in listOf(
+                        QuizType.TEXT_CHOICE_IMAGE,
+                        QuizType.SHORT_ANSWER_IMAGE
+                    )
+                ) {
                     if (isCorrect != QuizResultType.DEFAULT) {
                         Spacer(modifier = Modifier.height(QuizResultCardSpacer))
                         QuizResultCard(isCorrect = isCorrect == QuizResultType.CORRECT)
@@ -196,7 +218,7 @@ fun QuizScreen(
                 when (currentQuiz.quizType) {
                     QuizType.IMAGE_CHOICE -> {
                         val imageChoices = currentQuiz.imageUrl?.mapIndexed { index, imageUrl ->
-                            val label = currentQuiz.choices?.getOrNull(index)?: ""
+                            val label = currentQuiz.choices?.getOrNull(index) ?: ""
                             imageUrl to label
                         } ?: emptyList()
 
@@ -207,18 +229,26 @@ fun QuizScreen(
                             isCorrect = isCorrect,
                             onChoiceClick = { index ->
                                 onSelectedIndexChange(index)
-                                val isRight = index == (currentQuiz.answer[0] - 'A')
-                                onCorrectChange(if (isRight) QuizResultType.CORRECT else QuizResultType.WRONG)
+                                quizViewModel.checkAnswer(
+                                    selectedAnswer = ('A' + index).toString()
+                                )
                             }
                         )
                     }
 
                     QuizType.TEXT_CHOICE, QuizType.TEXT_CHOICE_IMAGE -> {
-                        val textChoices = currentQuiz.choices?: emptyList()
+                        val textChoices = currentQuiz.choices ?: emptyList()
 
                         if (currentQuiz.quizType == QuizType.TEXT_CHOICE_IMAGE) {
-                            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                                Spacer(modifier = Modifier.height(QuizResultCardTextChoiceImageSmallSpacer))
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Spacer(
+                                    modifier = Modifier.height(
+                                        QuizResultCardTextChoiceImageSmallSpacer
+                                    )
+                                )
 
                                 Box(modifier = Modifier.fillMaxWidth()) {
                                     AsyncImage(
@@ -248,16 +278,24 @@ fun QuizScreen(
                             isCorrect = isCorrect,
                             onChoiceClick = { index ->
                                 onSelectedIndexChange(index)
-                                val isRight = index == (currentQuiz.answer[0] - 'A')
-                                onCorrectChange(if (isRight) QuizResultType.CORRECT else QuizResultType.WRONG)
+                                quizViewModel.checkAnswer(
+                                    selectedAnswer = ('A' + index).toString()
+                                )
                             }
                         )
                     }
 
                     QuizType.SHORT_ANSWER, QuizType.SHORT_ANSWER_IMAGE -> {
                         if (currentQuiz.quizType == QuizType.SHORT_ANSWER_IMAGE) {
-                            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                                Spacer(modifier = Modifier.height(QuizResultCardTextChoiceImageSmallSpacer))
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Spacer(
+                                    modifier = Modifier.height(
+                                        QuizResultCardTextChoiceImageSmallSpacer
+                                    )
+                                )
                                 Box(modifier = Modifier.fillMaxWidth()) {
                                     AsyncImage(
                                         model = currentQuiz.imageUrl?.first(),
@@ -284,8 +322,10 @@ fun QuizScreen(
                             userInput = userInput,
                             answer = currentQuiz.answer,
                             onUserInputChange = onUserInputChange,
-                            onConfirmAnswer = { isCorrectAnswer ->
-                                onCorrectChange(if (isCorrectAnswer) QuizResultType.CORRECT else QuizResultType.WRONG)
+                            onConfirmAnswer = {
+                                quizViewModel.checkAnswer(
+                                    selectedAnswer = userInput
+                                )
                             }
                         )
                     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/QuizViewModel.kt
@@ -1,75 +1,165 @@
 package com.paykidscompose.presentation.screens.quiz
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.paykidscompose.common.enums.QuizClearType
 import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.quiz.GetAllQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckAnswerUseCase
+import com.paykidscompose.common.usecase.quiz.GetCheckStageUseCase
 import com.paykidscompose.presentation.base.UIState
-import com.paykidscompose.presentation.dummy.DummyQuiz
+import com.paykidscompose.presentation.mapper.quiz.QuizClearedUIModelMapper
+import com.paykidscompose.presentation.mapper.quiz.QuizUIModelMapper
 import com.paykidscompose.presentation.model.QuizUIModel
-import kotlinx.coroutines.delay
+import com.paykidscompose.presentation.model.type.QuizResultType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class QuizViewModel : ViewModel() {
+class QuizViewModel(
+    private val getAllQuizzesUseCase: GetAllQuizzesUseCase,
+    private val getCheckAnswerUseCase: GetCheckAnswerUseCase,
+    private val getCheckStageUseCase: GetCheckStageUseCase
+) : ViewModel() {
     private val _uiState = MutableStateFlow(QuizUIState())
     val uiState = _uiState.asStateFlow()
 
-    fun loadQuiz(stageNumber: Int) {
+    fun loadQuizzes(stageNumber: Int) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
 
-            delay(500)
+            getAllQuizzesUseCase(GetAllQuizzesUseCase.Params(stageNumber))
+                .collect { result ->
+                    when (result) {
+                        is DataResourceResult.Success -> {
+                            val quizzes =
+                                result.data.map { QuizUIModelMapper.mapToLayerModel(it) }.toMutableList()
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    quizzes = quizzes,
+                                    currentIndex = 0,
+                                    totalCount = quizzes.firstOrNull()?.totalCount ?: 0
+                                )
+                            }
+                            Log.d(TAG, "퀴즈 불러오기 성공: ${quizzes.size}개")
+                        }
 
-            runCatching {
-                val quizzes = DummyQuiz.getQuizzes(stageNumber).map { quiz ->
-                    QuizUIModel(
-                        quiz.stage,
-                        quiz.number,
-                        quiz.quizType,
-                        quiz.question,
-                        quiz.choices,
-                        quiz.answer,
-                        quiz.imageUrl,
-                        quiz.totalCount
-                    )
-                }.toMutableList()
+                        is DataResourceResult.Failure -> {
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    error = result.exception
+                                )
+                            }
+                            Log.d(TAG, "퀴즈 불러오기 실패: ${result.exception}")
+                        }
 
-                // 예외 상황 처리: 퀴즈가 비어 있으면 예외 발생
-                require(quizzes.isNotEmpty())
-
-                quizzes
-            }.onSuccess { quizzes ->
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        quizzes = quizzes,
-                        currentIndex = 0,
-                        totalCount = quizzes.first().totalCount
-                    )
+                        DataResourceResult.Loading -> {}
+                        DataResourceResult.DummyConstructor -> {}
+                    }
                 }
-            }.onFailure { e ->
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = PayKidsException.SnackBarException(message = e.message?: "")
-                    )
+        }
+    }
+
+    fun checkAnswer(selectedAnswer: String) {
+        val currentQuiz = uiState.value.currentQuiz ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(error = null) }
+
+            val result = getCheckAnswerUseCase(
+                GetCheckAnswerUseCase.Params(
+                    stage = currentQuiz.stage,
+                    number = currentQuiz.number,
+                    answer = selectedAnswer
+                )
+            )
+            when (result) {
+                is DataResourceResult.Success -> {
+                    val resultType = if (result.data) QuizResultType.CORRECT else QuizResultType.WRONG
+                    _uiState.update {
+                        it.copy(
+                            quizResultType = resultType,
+                        )
+                    }
+                    Log.d(TAG, "정답 여부: ${result.data}")
                 }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            quizResultType = QuizResultType.DEFAULT,
+                            error = result.exception
+                        )
+                    }
+                    Log.d(TAG, "정답 체크 실패: ${result.exception}")
+                }
+
+                DataResourceResult.Loading -> {}
+                DataResourceResult.DummyConstructor -> {}
             }
+        }
+
+    }
+
+    fun checkClearStage(onResult: (QuizClearType) -> Unit) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(error = null) }
+
+            when (val result = getCheckStageUseCase(
+                GetCheckStageUseCase.Params(uiState.value.currentQuiz?.stage ?: 0)
+            )) {
+                is DataResourceResult.Success -> {
+                    val clearedModel = QuizClearedUIModelMapper.mapToLayerModel(result.data)
+                    val clearType = when {
+                        clearedModel.message == "All Clear" && clearedModel.isCleared -> QuizClearType.ALL_CLEAR
+                        clearedModel.message == "First" && clearedModel.isCleared -> QuizClearType.CLEAR_SUCCESS
+                        clearedModel.message == "First" && !clearedModel.isCleared -> QuizClearType.CLEAR_FAILED
+                        clearedModel.message == "오답 노트" && clearedModel.isCleared -> QuizClearType.WRONG_ANSWER_QUIZ_CLEAR
+                        clearedModel.message == "오답 노트" && !clearedModel.isCleared -> QuizClearType.WRONG_ANSWER_QUIZ_FAILED
+                        clearedModel.message == "복습" && clearedModel.isCleared -> QuizClearType.REVIEW_COMPLETED
+                        else -> QuizClearType.CLEAR_FAILED
+                    }
+                    onResult(clearType)
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update { it.copy(error = result.exception) }
+                }
+
+                else -> Unit
+            }
+
         }
     }
 
     fun moveToNext() {
         _uiState.update {
             if (it.currentIndex < it.quizzes.lastIndex) {
-                it.copy(currentIndex = it.currentIndex + 1)
+                it.copy(
+                    currentIndex = it.currentIndex + 1,
+                    quizResultType = QuizResultType.DEFAULT
+                )
             } else it
         }
     }
 
     fun isLastQuiz(): Boolean {
         return uiState.value.currentIndex == uiState.value.quizzes.lastIndex
+    }
+
+    fun clearError() {
+        _uiState.update {
+            it.copy(error = null)
+        }
+    }
+
+    companion object {
+        private const val TAG = "QuizViewModel"
     }
 }
 
@@ -79,7 +169,8 @@ data class QuizUIState(
     val quizzes: MutableList<QuizUIModel> = mutableListOf(),
     val totalCount: Int = 0,
     val currentIndex: Int = 0,
-): UIState() {
+    val quizResultType: QuizResultType = QuizResultType.DEFAULT,
+) : UIState() {
     val currentQuiz: QuizUIModel?
         get() = quizzes.getOrNull(currentIndex)
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/section/ShortAnswerQuizContent.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/quiz/section/ShortAnswerQuizContent.kt
@@ -35,10 +35,9 @@ fun ShortAnswerQuizContent(
     userInput: String,
     answer: String,
     onUserInputChange: (String) -> Unit,
-    onConfirmAnswer: (Boolean) -> Unit
+    onConfirmAnswer: (String) -> Unit
 ) {
     var isSubmitted by remember { mutableStateOf(false) }
-    val isCorrectAnswer = userInput.trim() == answer.trim()
 
     OutlineInputField(
         text = userInput,
@@ -70,10 +69,7 @@ fun ShortAnswerQuizContent(
 
     DecisionButton(
         text = stringResource(R.string.text_confirm_nickname), onClick = {
-            if (!isSubmitted) {
-                onConfirmAnswer(isCorrectAnswer)
-                isSubmitted = true
-            }
+            onConfirmAnswer(userInput)
         },
         enabled = !isSubmitted, backgroundColor = if (isSubmitted) Gray2 else Blue2
     )


### PR DESCRIPTION
## 📝작업 내용

> 퀴즈 화면과 퀴즈 뷰모델 함수 연결 및 의존성 수동 주입

## 작업 상세 내용

- [x] QuizUIModelMapper imageUrl 오타 수정
- [x] 의존성 수동 주입
- [x] GetAllQuizzesUseCase 작성
- [x] QuizViewModel 퀴즈 전체 로드, 퀴즈 정답 여부 확인, 스테이지 클리어 여부 확인 함수 작성
- [x] 기존 더미 데이터 사용하면서 작성한 직접 퀴즈 정답 확인하는 로직 제거
- [ ] 퀴즈 푼 후 홈으로 재진입했을 때 스테이지 해금 갱신 안 되는 버그 수정

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> HomeScreen의 LaunchedEffect에서 뷰모델의 로드 함수를 호출하는데, 퀴즈를 다 풀고 난 후 홈으로 돌아왔을 때 스테이지 해금이 반영 안 되는 오류가 있습니다. 일단 앱을 재실행하면 갱신되는데 추후 수정하겠습니다. 