### PR TITLE
refactor: GetAllQuizzesUseCase 수정

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
+++ b/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
@@ -70,7 +70,7 @@ class ApplicationContainerImpl(
     override val getStageNameUseCase: GetStageNameUseCase = GetStageNameUseCase(quizRepository)
 
     override val getQuizUseCase: GetQuizUseCase = GetQuizUseCase(quizRepository)
-    override val getAllQuizzesUseCase: GetAllQuizzesUseCase = GetAllQuizzesUseCase(getQuizUseCase)
+    override val getAllQuizzesUseCase: GetAllQuizzesUseCase = GetAllQuizzesUseCase(quizRepository)
     override val getCheckAnswerUseCase: GetCheckAnswerUseCase = GetCheckAnswerUseCase(quizRepository)
     override val getCheckStageUseCase: GetCheckStageUseCase = GetCheckStageUseCase(quizRepository)
 

--- a/common/src/main/java/com/paykidscompose/common/usecase/quiz/GetAllQuizzesUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/quiz/GetAllQuizzesUseCase.kt
@@ -2,69 +2,61 @@ package com.paykidscompose.common.usecase.quiz
 
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.model.QuizModel
+import com.paykidscompose.common.repositories.QuizRepository
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.base.FlowUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
 class GetAllQuizzesUseCase(
-    private val getQuizUseCase: GetQuizUseCase
+    private val quizRepository: QuizRepository
 ) : FlowUseCase<GetAllQuizzesUseCase.Params, DataResourceResult<List<QuizModel>>>() {
     override fun execute(params: Params?): Flow<DataResourceResult<List<QuizModel>>> {
         if (params == null) {
-            return flowOf(DataResourceResult.Failure(PayKidsException.ToastException(code = -1, "")))
+            return flowOf(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = "퀴즈 요청 파라미터가 없습니다."
+                    )
+                )
+            )
         }
 
-        return flow {
-            runCatching {
-                coroutineScope {
-                    // 첫 번째 퀴즈 가져오기(퀴즈 데이터에 전체 퀴즈 개수가 포함되어 있기 때문에 첫 번째 퀴즈 먼저 로드)
-                    val firstResult = getQuizUseCase(
-                        GetQuizUseCase.Params(
-                            params.stage,
-                            1
-                        )
-                    ).first { it is DataResourceResult.Success || it is DataResourceResult.Failure }
-                    val firstQuiz = (firstResult as? DataResourceResult.Success)?.data
-                        ?: throw PayKidsException.ToastException(code = -1, "퀴즈 데이터를 불러올 수 없습니다.")
+        return flow<DataResourceResult<List<QuizModel>>> {
+            coroutineScope {
+                // 첫 번째 퀴즈 가져오기(퀴즈 데이터에 전체 퀴즈 개수가 포함되어 있기 때문에 첫 번째 퀴즈 먼저 로드)
+                val firstResult = quizRepository.getQuiz(params.stage, 1)
+                    .first { it is DataResourceResult.Success || it is DataResourceResult.Failure }
 
-                    val totalCount = firstQuiz.count
-                    // 나머지 퀴즈 병렬로 가져오기
-                    val rest = (2..totalCount).map { number ->
-                        async {
-                            getQuizUseCase(
-                                GetQuizUseCase.Params(
-                                    params.stage,
-                                    number
-                                )
-                            ).first { it is DataResourceResult.Success || it is DataResourceResult.Failure }
-                        }
-                    }.awaitAll()
-                        .mapNotNull { result ->
-                            (result as? DataResourceResult.Success)?.data
-                        }
+                val firstQuiz = (firstResult as? DataResourceResult.Success)?.data
+                    ?: throw PayKidsException.ToastException(-1, "퀴즈 데이터를 불러올 수 없습니다.")
 
-                    listOf(firstQuiz) + rest
-                }
-            }.fold(
-                onSuccess = { allQuizzes ->
-                    emit(DataResourceResult.Success(allQuizzes))
-                },
-                onFailure = {
-                    emit(
-                        DataResourceResult.Failure(
-                            PayKidsException.ToastException(
-                                code = -1,
-                                "퀴즈 전체 로딩 실패"
-                            )
-                        )
-                    )
-                }
+                val totalCount = firstQuiz.count
+                // 나머지 퀴즈 병렬로 가져오기
+                val otherResults = (2..totalCount).map { number ->
+                    async {
+                        quizRepository.getQuiz(params.stage, number)
+                            .first { it is DataResourceResult.Success || it is DataResourceResult.Failure }
+                    }
+                }.awaitAll()
+                    .mapNotNull { result ->
+                        (result as? DataResourceResult.Success)?.data
+                    }
+
+                emit(DataResourceResult.Success(listOf(firstQuiz) + otherResults))
+            }
+        }.catch {
+            emit(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(-1, "퀴즈 전체 로딩 실패)")
+                )
             )
         }
     }


### PR DESCRIPTION
## 📝작업 내용

> GetAllQuizzesUseCase 코드 리팩토링

## 작업 상세 내용

- [x] 유즈케이스 안에서 유즈케이스를 호출하지 않고 quizRepository.getQuiz()를 직접 호출하도록 변경
- [x] runCatching -> flow.catch로 변경

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)
> flow 안에 coroutineScope를 만들어도 되는지 찾아봤는데, 나머지 퀴즈들을 병렬로 가져오기 위해서는 coroutineScope 안에서 async-await 처리를 해야 한다고 합니다.
