### PR TITLE
refactor: 지출 분석 화면 수정

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity : ComponentActivity() {
                     ) ?: EntryPoint.LOGIN.name
                 )
             )
+
             PayKidsComposeTheme {
                 PayKidsApp(
                     loginStatus,
@@ -59,7 +60,14 @@ class MainActivity : ComponentActivity() {
                     provider.saveExpenseUseCase,
                     provider.saveIncomeUseCase,
                     provider.replaceExpenseUseCase,
-                    provider.replaceIncomeUseCase
+                    provider.replaceIncomeUseCase,
+                    provider.getIncomeMonthTotalAmountUseCase,
+                    provider.getExpenseMonthAllCategoryUseCase,
+                    provider.getIncomeMonthAllCategoryUseCase,
+                    provider.deleteExpenseCategoryUseCase,
+                    provider.deleteIncomeCategoryUseCase,
+                    provider.saveExpenseCategoryUseCase,
+                    provider.saveIncomeCategoryUseCase
                 )
             }
         }

--- a/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
+++ b/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
@@ -2,17 +2,24 @@ package com.paykidscompose.app.di
 
 import android.content.Context
 import com.paykidscompose.common.di.ApplicationContainer
+import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthMostCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.ReplaceExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthDailyAmountUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.ReplaceIncomeUseCase
+import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeUseCase
 import com.paykidscompose.common.usecase.authentication.LoginUseCase
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
@@ -23,8 +30,8 @@ import com.paykidscompose.common.usecase.quiz.GetQuizUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageCountUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
-import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
 import com.paykidscompose.common.usecase.user.DeleteUserUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.common.usecase.user.ReplaceNicknameUseCase
@@ -91,6 +98,22 @@ class ApplicationContainerImpl(
         GetWrongAnswerStatusUseCase(quizRepository)
     override val getCheckAnswerUseCase: GetCheckAnswerUseCase = GetCheckAnswerUseCase(quizRepository)
     override val getCheckStageUseCase: GetCheckStageUseCase = GetCheckStageUseCase(quizRepository)
+
+    override val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase =
+        GetIncomeMonthTotalAmountUseCase(incomeAllowanceRepository)
+    override val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase =
+        GetExpenseMonthAllCategoryUseCase(expenseAllowanceRepository)
+    override val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase =
+        GetIncomeMonthAllCategoryUseCase(incomeAllowanceRepository)
+    override val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase =
+        SaveExpenseCategoryUseCase(expenseCategoryRepository)
+    override val saveIncomeCategoryUseCase: SaveIncomeCategoryUseCase =
+        SaveIncomeCategoryUseCase(incomeCategoryRepository)
+
+    override val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase =
+        DeleteExpenseCategoryUseCase(expenseCategoryRepository)
+    override val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase =
+        DeleteIncomeCategoryUseCase(incomeCategoryRepository)
 
     override val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase =
         GetExpenseMonthTotalAmountUseCase(expenseAllowanceRepository)

--- a/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
+++ b/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
@@ -1,16 +1,23 @@
 package com.paykidscompose.common.di
 
+import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthMostCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.ReplaceExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthDailyAmountUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.ReplaceIncomeUseCase
+import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeUseCase
 import com.paykidscompose.common.usecase.authentication.LoginUseCase
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
@@ -21,8 +28,8 @@ import com.paykidscompose.common.usecase.quiz.GetQuizUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageCountUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
-import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
 import com.paykidscompose.common.usecase.user.DeleteUserUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.common.usecase.user.ReplaceNicknameUseCase
@@ -45,6 +52,9 @@ interface ApplicationContainer {
     val getCheckAnswerUseCase: GetCheckAnswerUseCase
     val getCheckStageUseCase: GetCheckStageUseCase
     val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase
+    val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase
+    val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase
+    val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase
     val getExpenseMonthMostCategoryUseCase: GetExpenseMonthMostCategoryUseCase
     val getExpenseMonthDailyAmountUseCase: GetExpenseMonthDailyAmountUseCase
     val getIncomeMonthDailyAmountUseCase: GetIncomeMonthDailyAmountUseCase
@@ -54,6 +64,10 @@ interface ApplicationContainer {
     val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase
     val saveExpenseUseCase: SaveExpenseUseCase
     val saveIncomeUseCase: SaveIncomeUseCase
+    val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase
+    val saveIncomeCategoryUseCase: SaveIncomeCategoryUseCase
     val replaceExpenseUseCase: ReplaceExpenseUseCase
     val replaceIncomeUseCase: ReplaceIncomeUseCase
+    val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase
+    val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase
 }

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/expense/SaveExpenseCategoryUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/expense/SaveExpenseCategoryUseCase.kt
@@ -10,10 +10,10 @@ class SaveExpenseCategoryUseCase(
 ) : SuspendUseCase<SaveExpenseCategoryUseCase.Params, DataResourceResult<Boolean>>() {
 
     override suspend fun execute(params: Params?): DataResourceResult<Boolean> {
-        return if (params != null) {
+        return if (params != null && params.category.length >= 1 && params.category.length <= 5) {
             repository.saveExpenseCategory(params.category)
         } else {
-            DataResourceResult.Failure(PayKidsException.ToastException(code = -1,"저장할 소비 카테고리를 제대로 입력하세요."))
+            DataResourceResult.Failure(PayKidsException.ToastException(code = -1,"카테고리는 1자 이상 5자 이하로 입력해주세요!"))
         }
     }
 

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/income/SaveIncomeCategoryUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/income/SaveIncomeCategoryUseCase.kt
@@ -10,10 +10,10 @@ class SaveIncomeCategoryUseCase(
 ) : SuspendUseCase<SaveIncomeCategoryUseCase.Params, DataResourceResult<Boolean>>() {
 
     override suspend fun execute(params: Params?): DataResourceResult<Boolean> {
-        return if (params != null) {
+        return if (params != null && params.category.length >= 1 && params.category.length <= 5) {
             repository.saveIncomeCategory(params.category)
         } else {
-            DataResourceResult.Failure(PayKidsException.ToastException(code = -1,"저장할 수입 카테고리를 제대로 입력하세요."))
+            DataResourceResult.Failure(PayKidsException.ToastException(code = -1,"카테고리는 1자 이상 5자 이하로 입력해주세요!"))
         }
     }
 

--- a/data/src/main/java/com/paykidscompose/data/mapper/allowance/AllowanceChartCategoryMapper.kt
+++ b/data/src/main/java/com/paykidscompose/data/mapper/allowance/AllowanceChartCategoryMapper.kt
@@ -7,10 +7,14 @@ import com.paykidscompose.data.model.allowance.AllowanceChartCategoryDTO
 
 object AllowanceChartCategoryMapper : ModelMapper<AllowanceChartCategoryModel, AllowanceChartCategoryDTO> {
     override fun mapToModel(layerModel: AllowanceChartCategoryDTO): AllowanceChartCategoryModel {
+
         return AllowanceChartCategoryModel(
             type = AllowanceType.valueOf(layerModel.allowanceType),
             category = layerModel.category,
-            percent = layerModel.percent?.toInt() ?: 0,
+            percent = layerModel.percent
+                ?.replace("%", "")
+                ?.toFloat()
+                ?.toInt() ?: 0,
             amount = layerModel.amount
         )
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/TransactionAnalysisViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/TransactionAnalysisViewModelFactory.kt
@@ -3,10 +3,12 @@ package com.paykidscompose.presentation.factory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
@@ -17,6 +19,8 @@ class TransactionAnalysisViewModelFactory(
     private val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
     private val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
     private val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
+    private val getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
+    private val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
     private val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
     private val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
     private val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
@@ -30,6 +34,8 @@ class TransactionAnalysisViewModelFactory(
                 getIncomeMonthTotalAmountUseCase,
                 getExpenseMonthAllCategoryUseCase,
                 getIncomeMonthAllCategoryUseCase,
+                getExpenseCategoryListUseCase,
+                getIncomeCategoryListUseCase,
                 deleteExpenseCategoryUseCase,
                 deleteIncomeCategoryUseCase,
                 saveExpenseCategoryUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/TransactionAnalysisViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/TransactionAnalysisViewModelFactory.kt
@@ -1,0 +1,41 @@
+package com.paykidscompose.presentation.factory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
+import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
+import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
+import com.paykidscompose.presentation.screens.allowance.analysis.TransactionAnalysisViewModel
+
+class TransactionAnalysisViewModelFactory(
+    private val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
+    private val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
+    private val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
+    private val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
+    private val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
+    private val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
+    private val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
+    private val saveIncomeCategoryUseCase: SaveIncomeCategoryUseCase
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(TransactionAnalysisViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return TransactionAnalysisViewModel(
+                getExpenseMonthTotalAmountUseCase,
+                getIncomeMonthTotalAmountUseCase,
+                getExpenseMonthAllCategoryUseCase,
+                getIncomeMonthAllCategoryUseCase,
+                deleteExpenseCategoryUseCase,
+                deleteIncomeCategoryUseCase,
+                saveExpenseCategoryUseCase,
+                saveIncomeCategoryUseCase
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/allowance/CategoryProgressBarUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/allowance/CategoryProgressBarUIModel.kt
@@ -1,0 +1,9 @@
+package com.paykidscompose.presentation.model.allowance
+
+import androidx.compose.ui.graphics.Color
+
+data class CategoryProgressBarUIModel(
+    val name: String,
+    val percent: Float,
+    val color: Color
+)

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/allowance/TransactionAnalysisUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/allowance/TransactionAnalysisUIModel.kt
@@ -1,0 +1,7 @@
+package com.paykidscompose.presentation.model.allowance
+
+import com.paykidscompose.presentation.model.UIModel
+
+data class TransactionAnalysisUIModel(
+    val transactionList: List<AllowanceChartCategoryUIModel> = emptyList()
+): UIModel()

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -17,17 +17,24 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.paykidscompose.common.enums.EntryPoint
+import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthMostCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.ReplaceExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthDailyAmountUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.ReplaceIncomeUseCase
+import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeUseCase
 import com.paykidscompose.common.usecase.authentication.LoginUseCase
 import com.paykidscompose.common.usecase.authentication.LogoutUseCase
@@ -37,8 +44,8 @@ import com.paykidscompose.common.usecase.quiz.GetCheckStageUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageCountUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
-import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerQuizzesUseCase
+import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
 import com.paykidscompose.common.usecase.user.DeleteUserUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.common.usecase.user.ReplaceNicknameUseCase
@@ -51,6 +58,7 @@ import com.paykidscompose.presentation.factory.MyInfoViewModelFactory
 import com.paykidscompose.presentation.factory.MyPageViewModelFactory
 import com.paykidscompose.presentation.factory.QuizEntryViewModelFactory
 import com.paykidscompose.presentation.factory.QuizViewModelFactory
+import com.paykidscompose.presentation.factory.TransactionAnalysisViewModelFactory
 import com.paykidscompose.presentation.navigation.route.AllowanceDiaryNavigationRoute
 import com.paykidscompose.presentation.navigation.route.EntryNavigationRoute
 import com.paykidscompose.presentation.navigation.route.MyPageNavigationRoute
@@ -59,7 +67,8 @@ import com.paykidscompose.presentation.navigation.route.TabNavigationRoute
 import com.paykidscompose.presentation.screens.PayKidsScaffold
 import com.paykidscompose.presentation.screens.allowance.AllowanceDiary
 import com.paykidscompose.presentation.screens.allowance.AllowanceDiaryViewModel
-import com.paykidscompose.presentation.screens.allowance.analysis.ExpenseAnalysis
+import com.paykidscompose.presentation.screens.allowance.analysis.TransactionAnalysis
+import com.paykidscompose.presentation.screens.allowance.analysis.TransactionAnalysisViewModel
 import com.paykidscompose.presentation.screens.allowance.detail.CategoryDetail
 import com.paykidscompose.presentation.screens.home.Home
 import com.paykidscompose.presentation.screens.home.HomeViewModel
@@ -110,7 +119,14 @@ fun PayKidsApp(
     saveExpenseUseCase: SaveExpenseUseCase,
     saveIncomeUseCase: SaveIncomeUseCase,
     replaceExpenseUseCase: ReplaceExpenseUseCase,
-    replaceIncomeUseCase: ReplaceIncomeUseCase
+    replaceIncomeUseCase: ReplaceIncomeUseCase,
+    getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
+    getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
+    getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
+    deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
+    deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
+    saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
+    saveIncomeCategoryUseCase: SaveIncomeCategoryUseCase
 ) {
     val navController: NavHostController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -342,7 +358,22 @@ fun PayKidsApp(
             }
 
             composable<AllowanceDiaryNavigationRoute.ExpenseAnalysisRoute> {
-                ExpenseAnalysis(
+                val viewModel: TransactionAnalysisViewModel = viewModel(
+                    viewModelStoreOwner = it,
+                    factory = TransactionAnalysisViewModelFactory(
+                        getExpenseMonthTotalAmountUseCase,
+                        getIncomeMonthTotalAmountUseCase,
+                        getExpenseMonthAllCategoryUseCase,
+                        getIncomeMonthAllCategoryUseCase,
+                        deleteExpenseCategoryUseCase,
+                        deleteIncomeCategoryUseCase,
+                        saveExpenseCategoryUseCase,
+                        saveIncomeCategoryUseCase
+                    )
+                )
+
+                TransactionAnalysis(
+                    viewModel = viewModel,
                     onCategoryCard = {
                         navController.navigate(AllowanceDiaryNavigationRoute.CategoryDetailRoute)
                     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -365,6 +365,8 @@ fun PayKidsApp(
                         getIncomeMonthTotalAmountUseCase,
                         getExpenseMonthAllCategoryUseCase,
                         getIncomeMonthAllCategoryUseCase,
+                        getExpenseCategoryListUseCase,
+                        getIncomeCategoryListUseCase,
                         deleteExpenseCategoryUseCase,
                         deleteIncomeCategoryUseCase,
                         saveExpenseCategoryUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
@@ -297,7 +297,11 @@ fun TransactionAnalysisScreen(
         Spacer(Modifier.height(AnalysisScreenSpacer34))
 
         Text(
-            stringResource(R.string.text_month_total_consume, formatAmount(totalAmount)),
+            if (selected == AllowanceType.EXPENSE) stringResource(
+                R.string.text_month_total_consume,
+                formatAmount(totalAmount)
+            )
+            else stringResource(R.string.text_month_total_income, formatAmount(totalAmount)),
             style = AllowanceDiaryTitleExpenseTextStyle
                 .copy(color = Black)
         )
@@ -340,6 +344,13 @@ fun TransactionAnalysisScreen(
                     "${it.percent}%", onCategoryCard
                 )
                 Spacer(Modifier.height(AnalysisScreenSpacer8))
+            }
+
+            if (transactionList.isEmpty()) {
+                item {
+                    AnalysisItem("기타", 0, "0%", onCategoryCard)
+                    Spacer(Modifier.height(AnalysisScreenSpacer8))
+                }
             }
 
             item {

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
@@ -27,7 +27,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -143,13 +146,19 @@ fun TransactionAnalysis(
         else -> {
             TransactionAnalysisScreen(
                 uiState.uiModel.transactionList,
+                uiState.isAddCategory,
+                uiState.category,
                 uiState.totalAmount,
-                onCategoryCard,
                 uiState.currentMonth,
                 uiState.selectedType,
+                { viewModel.inputCategory(it) },
+                { viewModel.onAddClick() },
+                onCategoryCard,
                 { viewModel.onPrevMonth() },
                 { viewModel.onNextMonth() },
-                { viewModel.onAllowanceTypeSelected(it) }
+                { viewModel.onAllowanceTypeSelected(it) },
+                { viewModel.cancelAddCategory() },
+                { viewModel.confirmAddCategory() }
             )
         }
     }
@@ -158,13 +167,19 @@ fun TransactionAnalysis(
 @Composable
 fun TransactionAnalysisScreen(
     transactionList: List<AllowanceChartCategoryUIModel>,
+    isAddCategory: Boolean,
+    category: String,
     totalAmount: Int,
-    onCategoryCard: () -> Unit,
     month: LocalDate,
     selected: AllowanceType,
+    inputCategory: (String) -> Unit,
+    onAddClick: () -> Unit,
+    onCategoryCard: () -> Unit,
     onPrevMonth: () -> Unit,
     onNextMonth: () -> Unit,
     onSelect: (AllowanceType) -> Unit,
+    cancelAddCategory: () -> Unit,
+    confirmAddCategory: () -> Unit
 ) {
     val progressBarUIModels = remember(transactionList) {
         assignColorsToCategories(transactionList)
@@ -346,6 +361,17 @@ fun TransactionAnalysisScreen(
                 Spacer(Modifier.height(AnalysisScreenSpacer8))
             }
 
+            if (isAddCategory) {
+                item {
+                    AddCategoryItem(
+                        category,
+                        inputCategory,
+                        cancelAddCategory,
+                        confirmAddCategory
+                    )
+                }
+            }
+
             if (transactionList.isEmpty()) {
                 item {
                     AnalysisItem("기타", 0, "0%", onCategoryCard)
@@ -355,7 +381,7 @@ fun TransactionAnalysisScreen(
 
             item {
                 Button(
-                    onClick = {},
+                    onClick = { onAddClick() },
                     shape = RoundedCornerShape(AnalysisScreenShape10),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = White2,
@@ -383,7 +409,7 @@ fun TransactionAnalysisScreen(
 }
 
 @Composable
-fun AnalysisItem(
+private fun AnalysisItem(
     category: String,
     amount: Int,
     percent: String,
@@ -432,6 +458,84 @@ fun AnalysisItem(
                 percent,
                 style = ExpenseAnalysisItemPercentTextStyle.copy(color = Gray1)
             )
+        }
+    }
+}
+
+@Composable
+private fun AddCategoryItem(
+    category: String,
+    inputCategory: (String) -> Unit,
+    cancelAddCategory: () -> Unit,
+    confirmAddCategory: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                onClick = {
+                }
+            )
+            .shadow(
+                elevation = CustomCardShadow,
+                shape = RoundedCornerShape(AllowanceDiaryScreenCardShape),
+                ambientColor = MyPageCardShadowColor,
+                spotColor = MyPageCardShadowColor
+            )
+            .background(
+                White, shape = RoundedCornerShape(AllowanceDiaryScreenCardShape)
+            )
+            .padding(
+                start = AllowanceDiaryScreenTransactionStartEndPadding,
+                end = AllowanceDiaryScreenTransactionStartEndPadding,
+                top = AllowanceDiaryScreenTransactionTopBottomPadding,
+                bottom = AllowanceDiaryScreenTransactionTopBottomPadding
+            ),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            OutlinedTextField(
+                value = category,
+                onValueChange = {
+                    if (it.length <= 5) inputCategory(it)
+                },
+                textStyle = ExpenseAnalysisItemCategoryTextStyle.copy(color = Blue1),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = Gray6,
+                    unfocusedContainerColor = Gray6,
+                    unfocusedBorderColor = Color.Transparent,
+                    focusedBorderColor = Color.Transparent
+                ),
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.width(AnalysisScreenSpacer8))
+
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.SpaceAround
+            ) {
+                TextButton(
+                    onClick = { confirmAddCategory() }
+                ) {
+                    Text(
+                        stringResource(R.string.analysis_text_save),
+                        style = ExpenseAnalysisProgressBarNameTextStyle.copy(color = Gray7)
+                    )
+                }
+
+                TextButton(
+                    onClick = { cancelAddCategory() }
+                ) {
+                    Text(
+                        stringResource(R.string.text_cancel),
+                        style = ExpenseAnalysisProgressBarNameTextStyle.copy(color = Gray1)
+                    )
+                }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
@@ -50,6 +50,7 @@ import com.paykidscompose.common.enums.AllowanceType
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.util.MonthFormatter
 import com.paykidscompose.presentation.R
+import com.paykidscompose.presentation.base.UIEvent
 import com.paykidscompose.presentation.model.allowance.AllowanceChartCategoryUIModel
 import com.paykidscompose.presentation.model.allowance.CategoryProgressBarUIModel
 import com.paykidscompose.presentation.ui.components.ScreenLoading
@@ -103,6 +104,7 @@ import com.paykidscompose.presentation.ui.theme.White
 import com.paykidscompose.presentation.ui.theme.White2
 import com.paykidscompose.presentation.util.assignColorsToCategories
 import com.paykidscompose.presentation.util.formatAmount
+import kotlinx.coroutines.flow.collectLatest
 import java.time.LocalDate
 
 @Composable
@@ -116,6 +118,16 @@ fun TransactionAnalysis(
 
     LaunchedEffect(Unit) {
         viewModel.load()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collectLatest { event ->
+            when (event) {
+                is UIEvent.SuccessShowToast -> {
+                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 
     LaunchedEffect(uiState.error) {
@@ -372,13 +384,6 @@ fun TransactionAnalysisScreen(
                 }
             }
 
-            if (transactionList.isEmpty()) {
-                item {
-                    AnalysisItem("기타", 0, "0%", onCategoryCard)
-                    Spacer(Modifier.height(AnalysisScreenSpacer8))
-                }
-            }
-
             item {
                 Button(
                     onClick = { onAddClick() },
@@ -543,6 +548,8 @@ private fun AddCategoryItem(
 
 @Composable
 private fun CategoryProgressBar(progressBarUIModels: List<CategoryProgressBarUIModel>) {
+    val totalPercent = progressBarUIModels.sumOf { it.percent.toDouble() }
+
     Column {
         Box(
             modifier = Modifier
@@ -552,13 +559,23 @@ private fun CategoryProgressBar(progressBarUIModels: List<CategoryProgressBarUIM
                 .border(AnalysisScreenBorderWidth1, Gray6, RoundedCornerShape(AnalysisScreenShape100))
         ) {
             Row(Modifier.fillMaxSize()) {
-                progressBarUIModels.forEach { item ->
+                if (totalPercent == 0.0) {
                     Box(
                         modifier = Modifier
-                            .weight(item.percent)
                             .fillMaxHeight()
-                            .background(item.color)
+                            .background(White)
                     )
+                } else {
+                    progressBarUIModels.forEach { item ->
+                        if (item.percent > 0f) {
+                            Box(
+                                modifier = Modifier
+                                    .weight(item.percent)
+                                    .fillMaxHeight()
+                                    .background(item.color)
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
@@ -1,6 +1,7 @@
 package com.paykidscompose.presentation.screens.allowance.analysis
 
 import android.widget.Toast
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -44,6 +45,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.paykidscompose.common.enums.AllowanceType
@@ -159,18 +161,23 @@ fun TransactionAnalysis(
             TransactionAnalysisScreen(
                 uiState.uiModel.transactionList,
                 uiState.isAddCategory,
+                uiState.isDeleteMode,
+                uiState.selectedCategoryForDelete,
                 uiState.category,
                 uiState.totalAmount,
                 uiState.currentMonth,
                 uiState.selectedType,
                 { viewModel.inputCategory(it) },
+                { viewModel.onToggleCategorySelection(it) },
                 { viewModel.onAddClick() },
                 onCategoryCard,
                 { viewModel.onPrevMonth() },
                 { viewModel.onNextMonth() },
                 { viewModel.onAllowanceTypeSelected(it) },
                 { viewModel.cancelAddCategory() },
-                { viewModel.confirmAddCategory() }
+                { viewModel.confirmAddCategory() },
+                { viewModel.enterDeleteMode() },
+                { viewModel.exitDeleteMode() }
             )
         }
     }
@@ -180,18 +187,23 @@ fun TransactionAnalysis(
 fun TransactionAnalysisScreen(
     transactionList: List<AllowanceChartCategoryUIModel>,
     isAddCategory: Boolean,
+    isDeleteMode: Boolean,
+    selectedCategoryForDelete: List<String>,
     category: String,
     totalAmount: Int,
     month: LocalDate,
     selected: AllowanceType,
     inputCategory: (String) -> Unit,
+    onToggleCategorySelection: (String) -> Unit,
     onAddClick: () -> Unit,
     onCategoryCard: () -> Unit,
     onPrevMonth: () -> Unit,
     onNextMonth: () -> Unit,
     onSelect: (AllowanceType) -> Unit,
     cancelAddCategory: () -> Unit,
-    confirmAddCategory: () -> Unit
+    confirmAddCategory: () -> Unit,
+    enterDeleteMode: () -> Unit,
+    exitDeleteMode: () -> Unit
 ) {
     val progressBarUIModels = remember(transactionList) {
         assignColorsToCategories(transactionList)
@@ -345,7 +357,12 @@ fun TransactionAnalysisScreen(
         Spacer(Modifier.height(AnalysisScreenSpacer34))
 
         Button(
-            onClick = {},
+            onClick = {
+                if (!isDeleteMode)
+                    enterDeleteMode()
+                else
+                    exitDeleteMode()
+            },
             shape = RoundedCornerShape(AnalysisScreenShape5),
             colors = ButtonDefaults.buttonColors(
                 containerColor = Gray7,
@@ -368,8 +385,17 @@ fun TransactionAnalysisScreen(
             items(transactionList) {
                 AnalysisItem(
                     it.category, it.amount,
-                    "${it.percent}%", onCategoryCard
-                )
+                    "${it.percent}%",
+                    isDeleteMode,
+                    selectedCategoryForDelete.contains(it.category)
+                ) {
+                    if (isDeleteMode) {
+                        onToggleCategorySelection(it.category)
+                    } else {
+                        onCategoryCard()
+                    }
+                }
+
                 Spacer(Modifier.height(AnalysisScreenSpacer8))
             }
 
@@ -418,6 +444,8 @@ private fun AnalysisItem(
     category: String,
     amount: Int,
     percent: String,
+    isDeleteMode: Boolean,
+    isSelected: Boolean,
     onCategoryCard: () -> Unit
 ) {
     Box(
@@ -454,15 +482,26 @@ private fun AnalysisItem(
                 style = ExpenseAnalysisItemCategoryTextStyle.copy(color = Blue1)
             )
 
-            Text(
-                formatAmount(amount),
-                style = ExpenseAnalysisItemAmountTextStyle.copy(color = Black)
-            )
+            if (isDeleteMode) {
+                Image(
+                    painter = painterResource(
+                        if (isSelected) R.drawable.ic_checkbox_checked else R.drawable.ic_checkbox_unchecked
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+            } else {
+                Text(
+                    formatAmount(amount),
+                    style = ExpenseAnalysisItemAmountTextStyle.copy(color = Black)
+                )
 
-            Text(
-                percent,
-                style = ExpenseAnalysisItemPercentTextStyle.copy(color = Gray1)
-            )
+                Text(
+                    percent,
+                    style = ExpenseAnalysisItemPercentTextStyle.copy(color = Gray1)
+                )
+            }
+
         }
     }
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.screens.allowance.analysis
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -28,22 +29,27 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.paykidscompose.common.enums.AllowanceType
+import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.util.MonthFormatter
 import com.paykidscompose.presentation.R
-import com.paykidscompose.presentation.dummy.AllowanceChartDTO
+import com.paykidscompose.presentation.model.allowance.AllowanceChartCategoryUIModel
+import com.paykidscompose.presentation.model.allowance.CategoryProgressBarUIModel
+import com.paykidscompose.presentation.ui.components.ScreenLoading
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryHeadMonthTextStyle
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenCardShape
 import com.paykidscompose.presentation.ui.theme.AllowanceDiaryScreenHeadIconSize
@@ -92,69 +98,77 @@ import com.paykidscompose.presentation.ui.theme.Gray9
 import com.paykidscompose.presentation.ui.theme.MyPageCardShadowColor
 import com.paykidscompose.presentation.ui.theme.White
 import com.paykidscompose.presentation.ui.theme.White2
+import com.paykidscompose.presentation.util.assignColorsToCategories
 import com.paykidscompose.presentation.util.formatAmount
 import java.time.LocalDate
 
 @Composable
-fun ExpenseAnalysis(
+fun TransactionAnalysis(
+    viewModel: TransactionAnalysisViewModel = viewModel(),
     onCategoryCard: () -> Unit = {}
 ) {
-    var currentMonth by remember {
-        mutableStateOf(
-            LocalDate.now()
-        )
-    }
-    var selectedAllowanceType by remember { mutableStateOf(AllowanceType.EXPENSE) }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val onSelectAllowanceType = { type: AllowanceType ->
-        selectedAllowanceType = type
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.load()
     }
 
-    val onMonth = { month: LocalDate ->
-        currentMonth = month
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            when (it) {
+                is PayKidsException.DialogException -> {
+
+                }
+
+                is PayKidsException.SnackBarException -> {
+
+                }
+
+                is PayKidsException.ToastException -> {
+                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            viewModel.clearError()
+        }
     }
 
-    var showInputDialog by remember { mutableStateOf(false) }
+    when {
+        uiState.isLoading -> {
+            ScreenLoading()
+        }
 
-    val onShowDialog = { value: Boolean ->
-        showInputDialog = value
+        else -> {
+            TransactionAnalysisScreen(
+                uiState.uiModel.transactionList,
+                uiState.totalAmount,
+                onCategoryCard,
+                uiState.currentMonth,
+                uiState.selectedType,
+                { viewModel.onPrevMonth() },
+                { viewModel.onNextMonth() },
+                { viewModel.onAllowanceTypeSelected(it) }
+            )
+        }
     }
-
-    if (showInputDialog) {
-//        AllowanceInputDialog(
-//            onSelect = {},
-//            onCancelClick = { showInputDialog = false }
-//        ) { showInputDialog = false }
-    }
-
-
-    ExpenseAnalysisScreen(
-        onCategoryCard,
-        currentMonth,
-        selectedAllowanceType,
-        onMonth,
-        onSelectAllowanceType
-    )
 }
 
 @Composable
-fun ExpenseAnalysisScreen(
+fun TransactionAnalysisScreen(
+    transactionList: List<AllowanceChartCategoryUIModel>,
+    totalAmount: Int,
     onCategoryCard: () -> Unit,
     month: LocalDate,
     selected: AllowanceType,
-    onMonth: (LocalDate) -> Unit,
+    onPrevMonth: () -> Unit,
+    onNextMonth: () -> Unit,
     onSelect: (AllowanceType) -> Unit,
 ) {
-    val data = calculateCategoryStats(
-        listOf(
-            AllowanceChartDTO(1, "2025-06-01", AllowanceType.EXPENSE, "편의점", 3000, "음료"),
-            AllowanceChartDTO(2, "2025-06-02", AllowanceType.EXPENSE, "식비", 12000, "점심"),
-            AllowanceChartDTO(3, "2025-06-03", AllowanceType.EXPENSE, "편의점", 2000, "간식"),
-            AllowanceChartDTO(4, "2025-06-04", AllowanceType.EXPENSE, "식비", 10000, "저녁"),
-            AllowanceChartDTO(5, "2025-06-05", AllowanceType.EXPENSE, "기타", 10000, "저녁")
-        )
-    )
-
+    val progressBarUIModels = remember(transactionList) {
+        assignColorsToCategories(transactionList)
+    }
 
     Column(
         modifier = Modifier
@@ -173,7 +187,7 @@ fun ExpenseAnalysisScreen(
         ) {
             IconButton(
                 onClick = {
-                    onMonth(month.minusMonths(1))
+                    onPrevMonth()
                 },
                 modifier = Modifier.size(AllowanceDiaryScreenHeadIconSize)
             ) {
@@ -190,7 +204,7 @@ fun ExpenseAnalysisScreen(
 
             IconButton(
                 onClick = {
-                    onMonth(month.plusMonths(1))
+                    onNextMonth()
                 },
                 modifier = Modifier.size(AllowanceDiaryScreenHeadIconSize)
             ) {
@@ -283,7 +297,7 @@ fun ExpenseAnalysisScreen(
         Spacer(Modifier.height(AnalysisScreenSpacer34))
 
         Text(
-            stringResource(R.string.text_month_total_consume, formatAmount(150000)),
+            stringResource(R.string.text_month_total_consume, formatAmount(totalAmount)),
             style = AllowanceDiaryTitleExpenseTextStyle
                 .copy(color = Black)
         )
@@ -294,7 +308,7 @@ fun ExpenseAnalysisScreen(
             modifier = Modifier
                 .fillMaxWidth()
         ) {
-            CategoryProgressBar(data)
+            CategoryProgressBar(progressBarUIModels)
         }
 
         Spacer(Modifier.height(AnalysisScreenSpacer34))
@@ -320,21 +334,15 @@ fun ExpenseAnalysisScreen(
         LazyColumn(
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(data) {
+            items(transactionList) {
                 AnalysisItem(
-                    it.name, it.amount,
-                    "${(it.percent * 100).toInt()}%", onCategoryCard
+                    it.category, it.amount,
+                    "${it.percent}%", onCategoryCard
                 )
                 Spacer(Modifier.height(AnalysisScreenSpacer8))
             }
 
             item {
-                AnalysisItem("기타", 0, "0%", onCategoryCard)
-                Spacer(Modifier.height(AnalysisScreenSpacer8))
-            }
-
-            item {
-
                 Button(
                     onClick = {},
                     shape = RoundedCornerShape(AnalysisScreenShape10),
@@ -370,13 +378,11 @@ fun AnalysisItem(
     percent: String,
     onCategoryCard: () -> Unit
 ) {
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(
                 onClick = {
-                    // CategoryDetailScreen으로 이동
                     onCategoryCard()
                 }
             )
@@ -421,9 +427,8 @@ fun AnalysisItem(
 
 
 @Composable
-private fun CategoryProgressBar(stats: List<CategoryStat>) {
+private fun CategoryProgressBar(progressBarUIModels: List<CategoryProgressBarUIModel>) {
     Column {
-        // ProgressBar 스타일 박스
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -432,12 +437,12 @@ private fun CategoryProgressBar(stats: List<CategoryStat>) {
                 .border(AnalysisScreenBorderWidth1, Gray6, RoundedCornerShape(AnalysisScreenShape100))
         ) {
             Row(Modifier.fillMaxSize()) {
-                stats.forEach { stat ->
+                progressBarUIModels.forEach { item ->
                     Box(
                         modifier = Modifier
-                            .weight(stat.percent)
+                            .weight(item.percent)
                             .fillMaxHeight()
-                            .background(stat.color)
+                            .background(item.color)
                     )
                 }
             }
@@ -450,18 +455,18 @@ private fun CategoryProgressBar(stats: List<CategoryStat>) {
             horizontalArrangement = Arrangement.spacedBy(AnalysisScreenProgressBarSpace),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            stats.forEach { stat ->
+            progressBarUIModels.forEach { item ->
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Box(
                         modifier = Modifier
                             .size(AnalysisScreenProgressBarSize)
-                            .background(stat.color, shape = CircleShape)
+                            .background(item.color, shape = CircleShape)
                     )
                     Spacer(Modifier.width(AnalysisScreenShape4))
                     Text(
-                        text = stat.name,
+                        text = item.name,
                         style = ExpenseAnalysisProgressBarNameTextStyle
                     )
                 }
@@ -470,42 +475,8 @@ private fun CategoryProgressBar(stats: List<CategoryStat>) {
     }
 }
 
-private data class CategoryStat(
-    val name: String,
-    val amount: Int,
-    val percent: Float,
-    val color: Color
-)
-
-private val categoryColors = mapOf(
-    "편의점" to Color(0xFF1976D2),
-    "식비" to Color(0xFF4FC3F7),
-    "교통비" to Color(0xFF64B5F6),
-    "문화생활" to Color(0xFFBA68C8),
-    "기타" to Color.Gray
-)
-
-private fun calculateCategoryStats(data: List<AllowanceChartDTO>): List<CategoryStat> {
-    val expenses = data.filter { it.allowanceType == AllowanceType.EXPENSE }
-
-    val total = expenses.sumOf { it.amount }
-    if (total == 0) return emptyList()
-
-    return expenses
-        .groupBy { it.category }
-        .map { (category, items) ->
-            val sum = items.sumOf { it.amount }
-            CategoryStat(
-                name = category,
-                amount = sum,
-                percent = sum.toFloat() / total,
-                color = categoryColors[category] ?: categoryColors["기타"]!!
-            )
-        }
-}
-
 @Preview
 @Composable
 fun AnalysisScreenPreview() {
-    ExpenseAnalysis()
+    TransactionAnalysis()
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
@@ -155,7 +155,7 @@ class TransactionAnalysisViewModel(
                 }
             }
 
-            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> TODO()
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
         }
     }
 
@@ -192,7 +192,7 @@ class TransactionAnalysisViewModel(
                 }
             }
 
-            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> TODO()
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
         }
     }
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
@@ -122,6 +122,118 @@ class TransactionAnalysisViewModel(
         }
     }
 
+    fun inputCategory(category: String) {
+        _uiState.update {
+            it.copy(
+                category = category
+            )
+        }
+    }
+
+    fun onAddClick() {
+        _uiState.update {
+            it.copy(
+                isAddCategory = true
+            )
+        }
+    }
+
+    fun cancelAddCategory() {
+        _uiState.update {
+            it.copy(
+                isAddCategory = false,
+                category = ""
+            )
+        }
+    }
+
+    fun confirmAddCategory() {
+        when (_uiState.value.selectedType) {
+            AllowanceType.INCOME -> {
+                saveIncomeCategory()
+            }
+            AllowanceType.EXPENSE -> {
+                saveExpenseCategory()
+            }
+        }
+    }
+
+    private fun saveExpenseCategory() {
+        if(!_uiState.value.isAddCategory) return
+
+        viewModelScope.launch {
+            val result = saveExpenseCategoryUseCase(
+                SaveExpenseCategoryUseCase.Params(
+                    _uiState.value.category
+                )
+            )
+
+            when (result) {
+                is DataResourceResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isAddCategory = false,
+                            category = ""
+                        )
+                    }
+
+                    _uiEvent.emit(UIEvent.SuccessShowToast("소비 카테고리를 저장했습니다!"))
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.exception,
+                            category = "",
+                            isAddCategory = false
+                        )
+                    }
+                }
+
+                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+            }
+        }
+    }
+
+    private fun saveIncomeCategory() {
+        if(!_uiState.value.isAddCategory) return
+
+        viewModelScope.launch {
+            val result = saveIncomeCategoryUseCase(
+                SaveIncomeCategoryUseCase.Params(
+                    _uiState.value.category
+                )
+            )
+
+            when (result) {
+                is DataResourceResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isAddCategory = false,
+                            category = ""
+                        )
+                    }
+
+                    _uiEvent.emit(UIEvent.SuccessShowToast("수입 카테고리를 저장했습니다!"))
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.exception,
+                            category = "",
+                            isAddCategory = false
+                        )
+                    }
+                }
+
+                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+            }
+        }
+    }
+
     private suspend fun getExpenseMonthTotalAmount() {
         _uiState.update {
             it.copy(
@@ -309,5 +421,7 @@ data class TransactionAnalysisUIState(
     val currentMonth: LocalDate = today.withDayOfMonth(1),
     val uiModel: TransactionAnalysisUIModel,
     val totalAmount: Int = 0,
+    val isAddCategory: Boolean = false,
+    val category: String = "",
     val selectedType: AllowanceType = AllowanceType.EXPENSE
 ) : UIState()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
@@ -1,0 +1,313 @@
+package com.paykidscompose.presentation.screens.allowance.analysis
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.paykidscompose.common.enums.AllowanceType
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
+import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
+import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
+import com.paykidscompose.common.util.today
+import com.paykidscompose.presentation.base.UIEvent
+import com.paykidscompose.presentation.base.UIState
+import com.paykidscompose.presentation.mapper.allowance.AllowanceChartCategoryUIModelMapper
+import com.paykidscompose.presentation.model.allowance.TransactionAnalysisUIModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+
+class TransactionAnalysisViewModel(
+    private val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
+    private val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
+    private val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
+    private val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
+    private val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
+    private val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
+    private val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
+    private val saveIncomeCategoryUseCase: SaveIncomeCategoryUseCase
+) : ViewModel() {
+    private val _uiState =
+        MutableStateFlow(TransactionAnalysisUIState(uiModel = TransactionAnalysisUIModel()))
+    val uiState = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<UIEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    fun load() {
+        viewModelScope.launch {
+            when (_uiState.value.selectedType) {
+                AllowanceType.INCOME -> {
+                    getIncomeMonthTotalAmount()
+                    getIncomeMonthAllCategory()
+                }
+
+                AllowanceType.EXPENSE -> {
+                    getExpenseMonthTotalAmount()
+                    getExpenseMonthAllCategory()
+                }
+            }
+        }
+    }
+
+    fun onPrevMonth() {
+        _uiState.update {
+            it.copy(currentMonth = it.currentMonth.minusMonths(1))
+        }
+
+        viewModelScope.launch {
+            when (_uiState.value.selectedType) {
+                AllowanceType.INCOME -> {
+                    getIncomeMonthTotalAmount()
+                    getIncomeMonthAllCategory()
+                }
+
+                AllowanceType.EXPENSE -> {
+                    getExpenseMonthTotalAmount()
+                    getExpenseMonthAllCategory()
+                }
+            }
+        }
+    }
+
+    fun onNextMonth() {
+        _uiState.update {
+            it.copy(currentMonth = it.currentMonth.plusMonths(1))
+        }
+
+        viewModelScope.launch {
+            when (_uiState.value.selectedType) {
+                AllowanceType.INCOME -> {
+                    getIncomeMonthTotalAmount()
+                    getIncomeMonthAllCategory()
+                }
+
+                AllowanceType.EXPENSE -> {
+                    getExpenseMonthTotalAmount()
+                    getExpenseMonthAllCategory()
+                }
+            }
+        }
+    }
+
+    fun onAllowanceTypeSelected(type: AllowanceType) {
+        _uiState.update {
+            it.copy(
+                selectedType = type
+            )
+        }
+
+        viewModelScope.launch {
+            when (_uiState.value.selectedType) {
+                AllowanceType.INCOME -> {
+                    getIncomeMonthTotalAmount()
+                    getIncomeMonthAllCategory()
+                }
+
+                AllowanceType.EXPENSE -> {
+                    getExpenseMonthTotalAmount()
+                    getExpenseMonthAllCategory()
+                }
+            }
+        }
+    }
+
+    private suspend fun getExpenseMonthTotalAmount() {
+        _uiState.update {
+            it.copy(
+                isLoading = true
+            )
+        }
+
+        val result = getExpenseMonthTotalAmountUseCase(
+            GetExpenseMonthTotalAmountUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue,
+            )
+        )
+
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        totalAmount = result.data
+                    )
+                }
+            }
+
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = result.exception
+                    )
+                }
+            }
+
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> TODO()
+        }
+    }
+
+    private suspend fun getIncomeMonthTotalAmount() {
+        _uiState.update {
+            it.copy(
+                isLoading = true
+            )
+        }
+
+        val result = getIncomeMonthTotalAmountUseCase(
+            GetIncomeMonthTotalAmountUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue,
+            )
+        )
+
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        totalAmount = result.data
+                    )
+                }
+            }
+
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = result.exception
+                    )
+                }
+            }
+
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> TODO()
+        }
+    }
+
+    private suspend fun getExpenseMonthAllCategory() {
+        _uiState.update {
+            it.copy(
+                isLoading = true
+            )
+        }
+
+        getExpenseMonthAllCategoryUseCase(
+            GetExpenseMonthAllCategoryUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue
+            )
+        ).collectLatest { result ->
+
+            when (result) {
+                is DataResourceResult.Success -> {
+                    val chartCategoryUIModels =
+                        result.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            uiModel = it.uiModel.copy(
+                                transactionList = chartCategoryUIModels
+                            )
+                        )
+                    }
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.exception
+                        )
+                    }
+                }
+
+                DataResourceResult.Loading -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = true
+                        )
+                    }
+                }
+
+                DataResourceResult.DummyConstructor -> {}
+            }
+        }
+    }
+
+    private suspend fun getIncomeMonthAllCategory() {
+        _uiState.update {
+            it.copy(
+                isLoading = true
+            )
+        }
+
+        getIncomeMonthAllCategoryUseCase(
+            GetIncomeMonthAllCategoryUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue
+            )
+        ).collectLatest { result ->
+
+            when (result) {
+                is DataResourceResult.Success -> {
+                    val chartCategoryUIModels =
+                        result.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            uiModel = it.uiModel.copy(
+                                transactionList = chartCategoryUIModels
+                            )
+                        )
+                    }
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.exception
+                        )
+                    }
+                }
+
+                DataResourceResult.Loading -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = true
+                        )
+                    }
+                }
+
+                DataResourceResult.DummyConstructor -> {}
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update {
+            it.copy(error = null)
+        }
+    }
+}
+
+data class TransactionAnalysisUIState(
+    override val isLoading: Boolean = false,
+    override val error: PayKidsException? = null,
+    val currentMonth: LocalDate = today.withDayOfMonth(1),
+    val uiModel: TransactionAnalysisUIModel,
+    val totalAmount: Int = 0,
+    val selectedType: AllowanceType = AllowanceType.EXPENSE
+) : UIState()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
@@ -6,10 +6,12 @@ import com.paykidscompose.common.enums.AllowanceType
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
@@ -17,12 +19,15 @@ import com.paykidscompose.common.util.today
 import com.paykidscompose.presentation.base.UIEvent
 import com.paykidscompose.presentation.base.UIState
 import com.paykidscompose.presentation.mapper.allowance.AllowanceChartCategoryUIModelMapper
+import com.paykidscompose.presentation.mapper.allowance.CategoryUIModelMapper
+import com.paykidscompose.presentation.model.allowance.AllowanceChartCategoryUIModel
 import com.paykidscompose.presentation.model.allowance.TransactionAnalysisUIModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -32,6 +37,8 @@ class TransactionAnalysisViewModel(
     private val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
     private val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
     private val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
+    private val getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
+    private val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
     private val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
     private val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
     private val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
@@ -49,12 +56,12 @@ class TransactionAnalysisViewModel(
             when (_uiState.value.selectedType) {
                 AllowanceType.INCOME -> {
                     getIncomeMonthTotalAmount()
-                    getIncomeMonthAllCategory()
+                    getIncomeAllCategoryForMonth()
                 }
 
                 AllowanceType.EXPENSE -> {
                     getExpenseMonthTotalAmount()
-                    getExpenseMonthAllCategory()
+                    getExpenseAllCategoryForMonth()
                 }
             }
         }
@@ -65,19 +72,7 @@ class TransactionAnalysisViewModel(
             it.copy(currentMonth = it.currentMonth.minusMonths(1))
         }
 
-        viewModelScope.launch {
-            when (_uiState.value.selectedType) {
-                AllowanceType.INCOME -> {
-                    getIncomeMonthTotalAmount()
-                    getIncomeMonthAllCategory()
-                }
-
-                AllowanceType.EXPENSE -> {
-                    getExpenseMonthTotalAmount()
-                    getExpenseMonthAllCategory()
-                }
-            }
-        }
+        load()
     }
 
     fun onNextMonth() {
@@ -85,19 +80,7 @@ class TransactionAnalysisViewModel(
             it.copy(currentMonth = it.currentMonth.plusMonths(1))
         }
 
-        viewModelScope.launch {
-            when (_uiState.value.selectedType) {
-                AllowanceType.INCOME -> {
-                    getIncomeMonthTotalAmount()
-                    getIncomeMonthAllCategory()
-                }
-
-                AllowanceType.EXPENSE -> {
-                    getExpenseMonthTotalAmount()
-                    getExpenseMonthAllCategory()
-                }
-            }
-        }
+        load()
     }
 
     fun onAllowanceTypeSelected(type: AllowanceType) {
@@ -107,19 +90,7 @@ class TransactionAnalysisViewModel(
             )
         }
 
-        viewModelScope.launch {
-            when (_uiState.value.selectedType) {
-                AllowanceType.INCOME -> {
-                    getIncomeMonthTotalAmount()
-                    getIncomeMonthAllCategory()
-                }
-
-                AllowanceType.EXPENSE -> {
-                    getExpenseMonthTotalAmount()
-                    getExpenseMonthAllCategory()
-                }
-            }
-        }
+        load()
     }
 
     fun inputCategory(category: String) {
@@ -152,14 +123,17 @@ class TransactionAnalysisViewModel(
             AllowanceType.INCOME -> {
                 saveIncomeCategory()
             }
+
             AllowanceType.EXPENSE -> {
                 saveExpenseCategory()
             }
         }
+
+        load()
     }
 
     private fun saveExpenseCategory() {
-        if(!_uiState.value.isAddCategory) return
+        if (!_uiState.value.isAddCategory) return
 
         viewModelScope.launch {
             val result = saveExpenseCategoryUseCase(
@@ -197,7 +171,7 @@ class TransactionAnalysisViewModel(
     }
 
     private fun saveIncomeCategory() {
-        if(!_uiState.value.isAddCategory) return
+        if (!_uiState.value.isAddCategory) return
 
         viewModelScope.launch {
             val result = saveIncomeCategoryUseCase(
@@ -308,102 +282,148 @@ class TransactionAnalysisViewModel(
         }
     }
 
-    private suspend fun getExpenseMonthAllCategory() {
+    private suspend fun getExpenseAllCategoryForMonth() {
         _uiState.update {
             it.copy(
                 isLoading = true
             )
         }
 
-        getExpenseMonthAllCategoryUseCase(
-            GetExpenseMonthAllCategoryUseCase.Params(
-                _uiState.value.currentMonth.year,
-                _uiState.value.currentMonth.monthValue
+        combine(
+            getExpenseCategoryListUseCase(),
+            getExpenseMonthAllCategoryUseCase(
+                GetExpenseMonthAllCategoryUseCase.Params(
+                    _uiState.value.currentMonth.year,
+                    _uiState.value.currentMonth.monthValue,
+                )
             )
-        ).collectLatest { result ->
+        ) { categoryResult, monthResult ->
+            Pair(categoryResult, monthResult)
+        }.collectLatest { (categoryResult, monthResult) ->
+            when {
+                categoryResult is DataResourceResult.Success && monthResult is DataResourceResult.Success -> {
+                    val allCategories = categoryResult.data.map { CategoryUIModelMapper.mapToLayerModel(it) }
+                    val monthCategory =
+                        monthResult.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
 
-            when (result) {
-                is DataResourceResult.Success -> {
-                    val chartCategoryUIModels =
-                        result.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
+                    val merge = allCategories.map { category ->
+                        val match = monthCategory.find { it.category == category.title }
+                        AllowanceChartCategoryUIModel(
+                            category = category.title,
+                            type = category.type,
+                            amount = match?.amount ?: 0,
+                            percent = match?.percent ?: 0
+                        )
+                    }
+
                     _uiState.update {
                         it.copy(
                             isLoading = false,
                             uiModel = it.uiModel.copy(
-                                transactionList = chartCategoryUIModels
+                                transactionList = merge
                             )
                         )
                     }
                 }
 
-                is DataResourceResult.Failure -> {
+                categoryResult is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            error = result.exception
+                            error = categoryResult.exception
                         )
                     }
                 }
 
-                DataResourceResult.Loading -> {
+                monthResult is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
-                            isLoading = true
+                            isLoading = false,
+                            error = monthResult.exception
                         )
                     }
                 }
 
-                DataResourceResult.DummyConstructor -> {}
+                else -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false
+                        )
+                    }
+                }
             }
         }
     }
 
-    private suspend fun getIncomeMonthAllCategory() {
+    private suspend fun getIncomeAllCategoryForMonth() {
         _uiState.update {
             it.copy(
                 isLoading = true
             )
         }
 
-        getIncomeMonthAllCategoryUseCase(
-            GetIncomeMonthAllCategoryUseCase.Params(
-                _uiState.value.currentMonth.year,
-                _uiState.value.currentMonth.monthValue
+        combine(
+            getIncomeCategoryListUseCase(),
+            getIncomeMonthAllCategoryUseCase(
+                GetIncomeMonthAllCategoryUseCase.Params(
+                    _uiState.value.currentMonth.year,
+                    _uiState.value.currentMonth.monthValue,
+                )
             )
-        ).collectLatest { result ->
+        ) { categoryResult, monthResult ->
+            Pair(categoryResult, monthResult)
+        }.collectLatest { (categoryResult, monthResult) ->
+            when {
+                categoryResult is DataResourceResult.Success && monthResult is DataResourceResult.Success -> {
+                    val allCategories = categoryResult.data.map { CategoryUIModelMapper.mapToLayerModel(it) }
+                    val monthCategory =
+                        monthResult.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
 
-            when (result) {
-                is DataResourceResult.Success -> {
-                    val chartCategoryUIModels =
-                        result.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
+                    val merge = allCategories.map { category ->
+                        val match = monthCategory.find { it.category == category.title }
+                        AllowanceChartCategoryUIModel(
+                            category = category.title,
+                            type = category.type,
+                            amount = match?.amount ?: 0,
+                            percent = match?.percent ?: 0
+                        )
+                    }
+
                     _uiState.update {
                         it.copy(
                             isLoading = false,
                             uiModel = it.uiModel.copy(
-                                transactionList = chartCategoryUIModels
+                                transactionList = merge
                             )
                         )
                     }
                 }
 
-                is DataResourceResult.Failure -> {
+                categoryResult is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            error = result.exception
+                            error = categoryResult.exception
                         )
                     }
                 }
 
-                DataResourceResult.Loading -> {
+                monthResult is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
-                            isLoading = true
+                            isLoading = false,
+                            error = monthResult.exception
                         )
                     }
                 }
 
-                DataResourceResult.DummyConstructor -> {}
+                else -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false
+                        )
+                    }
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisViewModel.kt
@@ -93,6 +93,54 @@ class TransactionAnalysisViewModel(
         load()
     }
 
+    fun enterDeleteMode() {
+        _uiState.update {
+            it.copy(
+                isDeleteMode = true
+            )
+        }
+    }
+
+    fun exitDeleteMode() {
+        if(_uiState.value.selectedCategoryForDelete.isNotEmpty()) {
+            viewModelScope.launch {
+                when (_uiState.value.selectedType) {
+                    AllowanceType.INCOME -> {
+                        deleteIncomeCategory()
+                        getIncomeMonthTotalAmount()
+                        getIncomeAllCategoryForMonth()
+                    }
+
+                    AllowanceType.EXPENSE -> {
+                        deleteExpenseCategory()
+                        getExpenseMonthTotalAmount()
+                        getExpenseAllCategoryForMonth()
+                    }
+                }
+            }
+        }
+
+        _uiState.update {
+            it.copy(
+                isDeleteMode = false,
+                selectedCategoryForDelete = emptyList()
+            )
+        }
+    }
+
+    fun onToggleCategorySelection(category: String) {
+        _uiState.update {
+            val current = it.selectedCategoryForDelete
+            val updated = if (category in current) {
+                current - category
+            } else {
+                current + category
+            }
+
+            it.copy(selectedCategoryForDelete = updated)
+        }
+    }
+
     fun inputCategory(category: String) {
         _uiState.update {
             it.copy(
@@ -130,6 +178,82 @@ class TransactionAnalysisViewModel(
         }
 
         load()
+    }
+
+    private suspend fun deleteExpenseCategory() {
+        if (!_uiState.value.isDeleteMode || _uiState.value.selectedCategoryForDelete.isEmpty()) return
+
+        _uiState.value.selectedCategoryForDelete.forEach { category ->
+            val result = deleteExpenseCategoryUseCase(
+                DeleteExpenseCategoryUseCase.Params(
+                    category
+                )
+            )
+
+            when (result) {
+                is DataResourceResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            selectedCategoryForDelete = it.selectedCategoryForDelete - category
+                        )
+                    }
+
+                    _uiEvent.emit(UIEvent.SuccessShowToast("$category 카테고리를 삭제했습니다!"))
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.exception
+                        )
+                    }
+                }
+
+                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+
+            }
+
+
+        }
+    }
+
+    private suspend fun deleteIncomeCategory() {
+        if (!_uiState.value.isDeleteMode || _uiState.value.selectedCategoryForDelete.isEmpty()) return
+
+        _uiState.value.selectedCategoryForDelete.forEach { category ->
+            val result = deleteIncomeCategoryUseCase(
+                DeleteIncomeCategoryUseCase.Params(
+                    category
+                )
+            )
+
+            when (result) {
+                is DataResourceResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            selectedCategoryForDelete = it.selectedCategoryForDelete - category
+                        )
+                    }
+
+                    _uiEvent.emit(UIEvent.SuccessShowToast("$category 카테고리를 삭제했습니다!"))
+                }
+
+                is DataResourceResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.exception
+                        )
+                    }
+                }
+
+                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+
+            }
+
+
+        }
     }
 
     private fun saveExpenseCategory() {
@@ -442,6 +566,8 @@ data class TransactionAnalysisUIState(
     val uiModel: TransactionAnalysisUIModel,
     val totalAmount: Int = 0,
     val isAddCategory: Boolean = false,
+    val isDeleteMode: Boolean = false,
     val category: String = "",
-    val selectedType: AllowanceType = AllowanceType.EXPENSE
+    val selectedType: AllowanceType = AllowanceType.EXPENSE,
+    val selectedCategoryForDelete: List<String> = emptyList()
 ) : UIState()

--- a/presentation/src/main/java/com/paykidscompose/presentation/util/ColorUtil.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/util/ColorUtil.kt
@@ -1,0 +1,34 @@
+package com.paykidscompose.presentation.util
+
+import androidx.compose.ui.graphics.Color
+import com.paykidscompose.presentation.model.allowance.AllowanceChartCategoryUIModel
+import com.paykidscompose.presentation.model.allowance.CategoryProgressBarUIModel
+
+val defaultColors = listOf(
+    Color(0xFFE57373), Color(0xFFF06292), Color(0xFFBA68C8), Color(0xFF9575CD),
+    Color(0xFF7986CB), Color(0xFF64B5F6), Color(0xFF4FC3F7), Color(0xFF4DD0E1),
+    Color(0xFF4DB6AC), Color(0xFF81C784), Color(0xFFAED581), Color(0xFFDCE775),
+    Color(0xFFFFD54F), Color(0xFFFFB74D), Color(0xFFFF8A65), Color(0xFFA1887F),
+    Color(0xFF90A4AE), Color(0xFFF48FB1), Color(0xFFCE93D8), Color(0xFFB39DDB),
+    Color(0xFF9FA8DA), Color(0xFF90CAF9), Color(0xFF80DEEA), Color(0xFF80CBC4),
+    Color(0xFFA5D6A7), Color(0xFFE6EE9C), Color(0xFFFFF59D), Color(0xFFFFE082),
+    Color(0xFFFFCC80), Color(0xFFFFAB91), Color(0xFFBCAAA4), Color(0xFFB0BEC5)
+)
+
+fun generateColorFromCategory(str: String): Color {
+    val hash = str.hashCode()
+    val index = (hash and 0x7FFFFFFF) % defaultColors.size
+    return defaultColors[index]
+}
+
+fun assignColorsToCategories(
+    data: List<AllowanceChartCategoryUIModel>
+): List<CategoryProgressBarUIModel> {
+    return data.map { item ->
+        CategoryProgressBarUIModel(
+            name = item.category,
+            percent = item.percent / 100f,
+            color = generateColorFromCategory(item.category)
+        )
+    }
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -127,6 +127,8 @@ z   <string name="text_quiz_number">%1$d/%2$d</string>
     <string name="text_delete_category">카테고리 삭제</string>
     <string name="text_add_category">+ 추가하기</string>
     <string name="text_delete">삭제하기</string>
+    <string name="text_cancel">취소</string>
+    <string name="analysis_text_save">저장</string>
 
     <!-- 퀘스트 페이지 -->
     <string name="text_tab_quest">퀘스트</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@ z   <string name="text_quiz_number">%1$d/%2$d</string>
 
     <!-- 용돈 일기 페이지 -->
     <string name="text_month_total_consume">%s원 사용 중</string>
+    <string name="text_month_total_income">%s원 확보 중</string>
     <string name="text_month_most_consume">%d월 달 %s에서 소비를 많이 했어요</string>
     <string name="text_category_consume">에서 %s원 사용 중</string>
     <string name="text_month_most_consume2">에서 소비를 많이 했어요</string>


### PR DESCRIPTION
## 📝작업 내용

> UI만 만들어져있던 지출 분석 화면을 api 호출하면서 실제 데이터 반영 및 삭제 추가 되도록 수정했습니다.

## 작업 상세 내용

- [x] 카테고리 추가 기능 구현
- [x] 카테고리 삭제 기능 구현
- [x] 소비 수입 타입에 맞게 알맞는 카테고리를 모두 가져오는 것을 구현
- [x] 유스케이스에 문자열의 길이 조건을 달았습니다.

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 지금은 기능 구현만 한다고 최적화나 효율적으로 작성 못한 거 같아요. 