### PR TITLE
refactor: 지출분석화면에서 기타 카테고리는 삭제하면 안돼서 삭제하기 모드에서 터치 안되도록 수정했습니다.

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/allowance/analysis/TransactionAnalysisScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.paykidscompose.common.enums.AllowanceType
@@ -70,6 +69,7 @@ import com.paykidscompose.presentation.ui.theme.AllowanceInputDialogToggleShadow
 import com.paykidscompose.presentation.ui.theme.AllowanceInputToggleTextStyle
 import com.paykidscompose.presentation.ui.theme.AnalysisScreenAddButtonVertical
 import com.paykidscompose.presentation.ui.theme.AnalysisScreenBorderWidth1
+import com.paykidscompose.presentation.ui.theme.AnalysisScreenCheckImageSize
 import com.paykidscompose.presentation.ui.theme.AnalysisScreenDeleteButtonHorizontal
 import com.paykidscompose.presentation.ui.theme.AnalysisScreenDeleteButtonVertical
 import com.paykidscompose.presentation.ui.theme.AnalysisScreenElevation16
@@ -382,8 +382,11 @@ fun TransactionAnalysisScreen(
         LazyColumn(
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(transactionList) {
+            items(transactionList, key = {
+                "${it.type}_${it.category}"
+            }) {
                 AnalysisItem(
+                    it.category == stringResource(R.string.analysis_text_etc),
                     it.category, it.amount,
                     "${it.percent}%",
                     isDeleteMode,
@@ -441,6 +444,7 @@ fun TransactionAnalysisScreen(
 
 @Composable
 private fun AnalysisItem(
+    isEtcCategory: Boolean = false,
     category: String,
     amount: Int,
     percent: String,
@@ -452,6 +456,7 @@ private fun AnalysisItem(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(
+                enabled = !(isEtcCategory && isDeleteMode),
                 onClick = {
                     onCategoryCard()
                 }
@@ -483,13 +488,15 @@ private fun AnalysisItem(
             )
 
             if (isDeleteMode) {
-                Image(
-                    painter = painterResource(
-                        if (isSelected) R.drawable.ic_checkbox_checked else R.drawable.ic_checkbox_unchecked
-                    ),
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp)
-                )
+                if (!isEtcCategory) {
+                    Image(
+                        painter = painterResource(
+                            if (isSelected) R.drawable.ic_checkbox_checked else R.drawable.ic_checkbox_unchecked
+                        ),
+                        contentDescription = null,
+                        modifier = Modifier.size(AnalysisScreenCheckImageSize)
+                    )
+                }
             } else {
                 Text(
                     formatAmount(amount),

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -286,6 +286,7 @@ val AllowanceInputDialogDateItemStartEndPadding = 8.dp
 val AllowanceInputDialogDateItemTopBottomPadding = 4.dp
 
 // 용돈일기 분석 화면
+val AnalysisScreenCheckImageSize = 20.dp
 val AnalysisScreenStartEndPadding = 17.dp
 val AnalysisScreenTopPadding = 20.dp
 val AnalysisScreenSpacer8 = 8.dp

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@ z   <string name="text_quiz_number">%1$d/%2$d</string>
     <string name="text_delete">삭제하기</string>
     <string name="text_cancel">취소</string>
     <string name="analysis_text_save">저장</string>
+    <string name="analysis_text_etc">기타</string>
 
     <!-- 퀘스트 페이지 -->
     <string name="text_tab_quest">퀘스트</string>


### PR DESCRIPTION
## 📝작업 내용

> 지출분석화면에서 기타 카테고리는 삭제하면 안돼서 삭제하기 모드에서 터치 안되도록 수정했습니다.

## 작업 상세 내용

- [ ] TODO
- [ ] TODO
- [ ] TODO

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
