### PR TITLE
feat: 학습하기 화면 채팅 api 연결

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -49,6 +49,7 @@ class MainActivity : ComponentActivity() {
                     provider.getWrongAnswerStatusUseCase,
                     provider.getCheckAnswerUseCase,
                     provider.getCheckStageUseCase,
+                    provider.getChatResponseUseCase,
                     provider.getExpenseMonthTotalAmountUseCase,
                     provider.getExpenseMonthMostCategoryUseCase,
                     provider.getExpenseMonthDailyAmountUseCase,

--- a/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
+++ b/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
@@ -32,6 +32,8 @@ import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerQuizzesUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
+import com.paykidscompose.common.usecase.study.GetChatCountUseCase
+import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
 import com.paykidscompose.common.usecase.user.DeleteUserUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.common.usecase.user.ReplaceNicknameUseCase
@@ -39,6 +41,7 @@ import com.paykidscompose.common.usecase.user.SaveNicknameUseCase
 import com.paykidscompose.data.network.NetworkModule
 import com.paykidscompose.data.network.service.authentication.KakaoLoginService
 import com.paykidscompose.data.repositories.AuthRepositoryImpl
+import com.paykidscompose.data.repositories.ChatRepositoryImpl
 import com.paykidscompose.data.repositories.ExpenseAllowanceRepositoryImpl
 import com.paykidscompose.data.repositories.ExpenseCategoryRepositoryImpl
 import com.paykidscompose.data.repositories.IncomeAllowanceRepositoryImpl
@@ -63,6 +66,9 @@ class ApplicationContainerImpl(
         NetworkModule.provideQuizApiService()
     )
 
+    private val chatRepository = ChatRepositoryImpl(
+        NetworkModule.provideChatApiService()
+    )
     private val expenseAllowanceRepository = ExpenseAllowanceRepositoryImpl(
         NetworkModule.provideExpenseApiService()
     )
@@ -98,6 +104,9 @@ class ApplicationContainerImpl(
         GetWrongAnswerStatusUseCase(quizRepository)
     override val getCheckAnswerUseCase: GetCheckAnswerUseCase = GetCheckAnswerUseCase(quizRepository)
     override val getCheckStageUseCase: GetCheckStageUseCase = GetCheckStageUseCase(quizRepository)
+
+    override val getChatResponseUseCase: GetChatResponseUseCase = GetChatResponseUseCase(chatRepository)
+    override val getChatCountUseCase: GetChatCountUseCase = GetChatCountUseCase(chatRepository)
 
     override val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase =
         GetIncomeMonthTotalAmountUseCase(incomeAllowanceRepository)

--- a/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
+++ b/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
@@ -30,6 +30,8 @@ import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerQuizzesUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
+import com.paykidscompose.common.usecase.study.GetChatCountUseCase
+import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
 import com.paykidscompose.common.usecase.user.DeleteUserUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.common.usecase.user.ReplaceNicknameUseCase
@@ -51,6 +53,8 @@ interface ApplicationContainer {
     val getWrongAnswerStatusUseCase: GetWrongAnswerStatusUseCase
     val getCheckAnswerUseCase: GetCheckAnswerUseCase
     val getCheckStageUseCase: GetCheckStageUseCase
+    val getChatResponseUseCase: GetChatResponseUseCase
+    val getChatCountUseCase: GetChatCountUseCase
     val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase
     val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase
     val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase

--- a/common/src/main/java/com/paykidscompose/common/model/study/ChatResponseModel.kt
+++ b/common/src/main/java/com/paykidscompose/common/model/study/ChatResponseModel.kt
@@ -3,5 +3,5 @@ package com.paykidscompose.common.model.study
 import com.paykidscompose.common.model.Model
 
 data class ChatResponseModel (
-    val response: Map<String, String>
+    val response: String
 ): Model()

--- a/common/src/main/java/com/paykidscompose/common/usecase/study/GetChatResponseUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/study/GetChatResponseUseCase.kt
@@ -6,16 +6,55 @@ import com.paykidscompose.common.repositories.ChatRepository
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.base.FlowUseCase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 
 class GetChatResponseUseCase(
     private val chatRepository: ChatRepository
 ) : FlowUseCase<GetChatResponseUseCase.Params, DataResourceResult<ChatResponseModel>>() {
-    override fun execute(params: Params?): Flow<DataResourceResult<ChatResponseModel>> {
-        return if (params != null) {
-            chatRepository.getChatResponse(params.prompt)
-        } else {
-            flowOf(DataResourceResult.Failure(PayKidsException.ToastException(code = -1,"")))
+    override fun execute(params: Params?): Flow<DataResourceResult<ChatResponseModel>> = flow {
+        if (params == null) {
+            emit(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = "요청 파라미터가 없습니다."
+                    )
+                )
+            )
+            return@flow
+        }
+
+        when (val countResult = chatRepository.getChatCount()) {
+            is DataResourceResult.Success -> {
+                val count = countResult.data
+                if (count <= 0) { // 남은 요청 횟수가 0이 되면 GPT 요청 불가능
+                    emit(
+                        DataResourceResult.Failure(
+                            PayKidsException.ToastException(
+                                code = -1,
+                                message = "더 이상 요청할 수 없습니다."
+                            )
+                        )
+                    )
+                } else {
+                    emitAll(chatRepository.getChatResponse(params.prompt))
+                }
+            }
+
+            is DataResourceResult.Failure -> {
+                emit(
+                    DataResourceResult.Failure(
+                        PayKidsException.ToastException(
+                            code = -1,
+                            message = "채팅 카운트를 불러오는 데 실패했습니다."
+                        )
+                    )
+                )
+            }
+
+            DataResourceResult.DummyConstructor -> {}
+            DataResourceResult.Loading -> {}
         }
     }
 

--- a/data/src/main/java/com/paykidscompose/data/model/study/ChatResponseDTO.kt
+++ b/data/src/main/java/com/paykidscompose/data/model/study/ChatResponseDTO.kt
@@ -4,5 +4,5 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ChatResponseDTO(
-    val response: Map<String, String>
+    val response: String
 )

--- a/data/src/main/java/com/paykidscompose/data/repositories/ChatRepositoryImpl.kt
+++ b/data/src/main/java/com/paykidscompose/data/repositories/ChatRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.paykidscompose.common.model.study.ChatResponseModel
 import com.paykidscompose.common.repositories.ChatRepository
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.data.mapper.study.ChatResponseMapper
-import com.paykidscompose.data.network.NetworkModule
 import com.paykidscompose.data.network.service.ChatApiService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/StudyViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/StudyViewModelFactory.kt
@@ -3,14 +3,16 @@ package com.paykidscompose.presentation.factory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
+import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.presentation.screens.study.StudyViewModel
 
 class StudyViewModelFactory(
-    private val getChatResponseUseCase: GetChatResponseUseCase
+    private val getChatResponseUseCase: GetChatResponseUseCase,
+    private val getUserUseCase: GetUserUseCase
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(StudyViewModel::class.java)) {
-            return StudyViewModel(getChatResponseUseCase) as T
+            return StudyViewModel(getChatResponseUseCase, getUserUseCase) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/StudyViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/StudyViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.paykidscompose.presentation.factory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
+import com.paykidscompose.presentation.screens.study.StudyViewModel
+
+class StudyViewModelFactory(
+    private val getChatResponseUseCase: GetChatResponseUseCase
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(StudyViewModel::class.java)) {
+            return StudyViewModel(getChatResponseUseCase) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/mapper/study/ChatMessageUIModelMapper.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/mapper/study/ChatMessageUIModelMapper.kt
@@ -11,7 +11,7 @@ object ChatMessageUIModelMapper: ModelMapper<ChatResponseModel, ChatMessageUIMod
 
     override fun mapToLayerModel(model: ChatResponseModel): ChatMessageUIModel {
         return ChatMessageUIModel(
-            text = model.response.values.firstOrNull() ?: "",
+            text = model.response,
             isFromGpt = true
         )
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -288,7 +288,8 @@ fun PayKidsApp(
                 val viewModel: StudyViewModel = viewModel(
                     viewModelStoreOwner = backStack,
                     factory = StudyViewModelFactory(
-                        getChatResponseUseCase
+                        getChatResponseUseCase,
+                        getUserUseCase
                     )
                 )
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -46,6 +46,7 @@ import com.paykidscompose.common.usecase.quiz.GetStageNameUseCase
 import com.paykidscompose.common.usecase.quiz.GetStageToGoUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerQuizzesUseCase
 import com.paykidscompose.common.usecase.quiz.GetWrongAnswerStatusUseCase
+import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
 import com.paykidscompose.common.usecase.user.DeleteUserUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.common.usecase.user.ReplaceNicknameUseCase
@@ -58,6 +59,7 @@ import com.paykidscompose.presentation.factory.MyInfoViewModelFactory
 import com.paykidscompose.presentation.factory.MyPageViewModelFactory
 import com.paykidscompose.presentation.factory.QuizEntryViewModelFactory
 import com.paykidscompose.presentation.factory.QuizViewModelFactory
+import com.paykidscompose.presentation.factory.StudyViewModelFactory
 import com.paykidscompose.presentation.factory.TransactionAnalysisViewModelFactory
 import com.paykidscompose.presentation.navigation.route.AllowanceDiaryNavigationRoute
 import com.paykidscompose.presentation.navigation.route.EntryNavigationRoute
@@ -83,11 +85,12 @@ import com.paykidscompose.presentation.screens.mypage.info.MyInfoViewModel
 import com.paykidscompose.presentation.screens.mypage.terms.TermsPolicyScreen
 import com.paykidscompose.presentation.screens.quest.QuestAndAchievement
 import com.paykidscompose.presentation.screens.quiz.Quiz
+import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.quiz.clear.QuizClear
 import com.paykidscompose.presentation.screens.quiz.entry.QuizEntry
 import com.paykidscompose.presentation.screens.quiz.entry.QuizEntryViewModel
-import com.paykidscompose.presentation.screens.quiz.QuizViewModel
 import com.paykidscompose.presentation.screens.study.Study
+import com.paykidscompose.presentation.screens.study.StudyViewModel
 import com.paykidscompose.presentation.ui.components.AppBottomBar
 
 
@@ -108,6 +111,7 @@ fun PayKidsApp(
     getWrongAnswerStatusUseCase: GetWrongAnswerStatusUseCase,
     getCheckAnswerUseCase: GetCheckAnswerUseCase,
     getCheckStageUseCase: GetCheckStageUseCase,
+    getChatResponseUseCase: GetChatResponseUseCase,
     getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
     getExpenseMonthMostCategoryUseCase: GetExpenseMonthMostCategoryUseCase,
     getExpenseMonthDailyAmountUseCase: GetExpenseMonthDailyAmountUseCase,
@@ -281,8 +285,16 @@ fun PayKidsApp(
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.StudyRoute>()
                 val stageNumber = targetRoute.stageNumber
 
+                val viewModel: StudyViewModel = viewModel(
+                    viewModelStoreOwner = backStack,
+                    factory = StudyViewModelFactory(
+                        getChatResponseUseCase
+                    )
+                )
+
                 Study(
                     stageNumber = stageNumber,
+                    studyViewModel = viewModel,
                     onBackClick = {
                         navController.navigateUp()
                     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
@@ -93,7 +93,7 @@ fun Study(
     val context = LocalContext.current
 
     val stageNumberText = stringResource(R.string.text_stage_number, stageNumber)
-    val userNickname = "닉네임"
+    val userNickname = uiState.userNickname
 
     val listState = rememberLazyListState()
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyScreen.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.presentation.screens.study
 
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -23,23 +24,24 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.study.ChatMessageUIModel
 import com.paykidscompose.presentation.screens.study.section.StudyTopBar
 import com.paykidscompose.presentation.ui.components.OutlineInputField
+import com.paykidscompose.presentation.ui.components.ScreenLoading
 import com.paykidscompose.presentation.ui.theme.Blue1
 import com.paykidscompose.presentation.ui.theme.Gray1
 import com.paykidscompose.presentation.ui.theme.Gray5
@@ -79,49 +81,61 @@ import com.paykidscompose.presentation.ui.theme.StudyStageNumberBoxTextStyle
 import com.paykidscompose.presentation.ui.theme.StudyStageNumberBoxVerticalPadding
 import com.paykidscompose.presentation.ui.theme.White
 import com.paykidscompose.presentation.ui.theme.White4
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @Composable
 fun Study(
     stageNumber: Int,
+    studyViewModel: StudyViewModel = viewModel(),
     onBackClick: () -> Unit = {}
 ) {
-    val messages = remember {
-        mutableStateListOf(
-            ChatMessageUIModel("어린이 여러분 돈이란 무엇일까요?\n돈이 뭐냐면 사고 싶은 걸 살 수 있는 거랍니다", isFromGpt = true),
-            ChatMessageUIModel("우와 그렇구나\n돈 없이는 사고 싶은 걸 가질 수 없나요?", isFromGpt = false),
-        )
-    }
+    val uiState by studyViewModel.uiState.collectAsStateWithLifecycle()
+
+    val context = LocalContext.current
+
     val stageNumberText = stringResource(R.string.text_stage_number, stageNumber)
     val userNickname = "닉네임"
-    var userInput by remember { mutableStateOf("") }
 
     val listState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
 
-    StudyScreen(
-        modifier = Modifier
-            .fillMaxSize(),
-        stageNumberText = stageNumberText,
-        userNickname = userNickname,
-        messages = messages,
-        userInput = userInput,
-        onBackClick = onBackClick,
-        onUserInputChange = { userInput = it },
-        onSendClick = {
-            if (userInput.isNotBlank()) {
-                messages.add(ChatMessageUIModel(userInput, isFromGpt = false))
-                userInput = ""
-                coroutineScope.launch {
-                    delay(500)
-                    messages.add(ChatMessageUIModel("GPT 응답 예시", isFromGpt = true))
-                    listState.animateScrollToItem(messages.size - 1)
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            when (it) {
+                is PayKidsException.SnackBarException -> {
+                }
+
+                is PayKidsException.DialogException -> {
+                }
+
+                is PayKidsException.ToastException -> {
+                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
                 }
             }
-        },
-        listState = listState
-    )
+
+            studyViewModel.clearError()
+        }
+    }
+
+    when {
+        uiState.isLoading -> {
+            ScreenLoading()
+        }
+        else -> {
+            StudyScreen(
+                modifier = Modifier
+                    .fillMaxSize(),
+                stageNumberText = stageNumberText,
+                userNickname = userNickname,
+                messages = uiState.messages,
+                userInput = uiState.userInput,
+                onBackClick = onBackClick,
+                onUserInputChange = { text -> studyViewModel.onUserInputChange(text) },
+                onSendClick = {
+                    studyViewModel.sendUserInput()
+                },
+                listState = listState
+            )
+        }
+    }
 }
 
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyViewModel.kt
@@ -65,7 +65,7 @@ class StudyViewModel(
                         }
 
                         is DataResourceResult.Failure -> {
-                            _uiState.update { it.copy(error = result.exception) }
+                            _uiState.update { it.copy(error = result.exception, isLoading = false) }
                         }
 
                         DataResourceResult.Loading -> {}
@@ -104,6 +104,7 @@ class StudyViewModel(
                             )
                         }
                     }
+
                     DataResourceResult.Loading -> {}
                     DataResourceResult.DummyConstructor -> {}
                 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
+import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.presentation.base.UIState
+import com.paykidscompose.presentation.mapper.my.MyInfoUIModelMapper
 import com.paykidscompose.presentation.model.study.ChatMessageUIModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,10 +16,15 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class StudyViewModel(
-    private val getChatResponseUseCase: GetChatResponseUseCase
+    private val getChatResponseUseCase: GetChatResponseUseCase,
+    private val getUserUseCase: GetUserUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(StudyUIState())
     val uiState = _uiState.asStateFlow()
+
+    init {
+        loadNickname()
+    }
 
     fun onUserInputChange(input: String) {
         _uiState.update { it.copy(userInput = input) }
@@ -68,6 +75,42 @@ class StudyViewModel(
         }
     }
 
+    fun loadNickname() {
+        if (_uiState.value.isLoading) return
+
+        _uiState.update {
+            it.copy(isLoading = true, error = null)
+        }
+
+        viewModelScope.launch {
+            getUserUseCase().collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Success -> {
+                        val uiModel = MyInfoUIModelMapper.mapToLayerModel(result.data)
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                userNickname = uiModel.nickname,
+                                error = null
+                            )
+                        }
+                    }
+
+                    is DataResourceResult.Failure -> {
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                error = result.exception
+                            )
+                        }
+                    }
+                    DataResourceResult.Loading -> {}
+                    DataResourceResult.DummyConstructor -> {}
+                }
+            }
+        }
+    }
+
     fun clearError() {
         _uiState.update {
             it.copy(error = null)
@@ -79,5 +122,6 @@ data class StudyUIState(
     override val isLoading: Boolean = false,
     override val error: PayKidsException? = null,
     val messages: List<ChatMessageUIModel> = listOf(),
-    val userInput: String = ""
+    val userInput: String = "",
+    val userNickname: String = ""
 ) : UIState()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screens/study/StudyViewModel.kt
@@ -1,0 +1,83 @@
+package com.paykidscompose.presentation.screens.study
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
+import com.paykidscompose.presentation.base.UIState
+import com.paykidscompose.presentation.model.study.ChatMessageUIModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class StudyViewModel(
+    private val getChatResponseUseCase: GetChatResponseUseCase
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(StudyUIState())
+    val uiState = _uiState.asStateFlow()
+
+    fun onUserInputChange(input: String) {
+        _uiState.update { it.copy(userInput = input) }
+    }
+
+    fun sendUserInput() {
+        val inputText = _uiState.value.userInput
+        if (inputText.isBlank()) return
+
+        val userMessage = ChatMessageUIModel(
+            text = inputText,
+            isFromGpt = false
+        )
+
+        _uiState.update {
+            it.copy(
+                messages = it.messages + userMessage,
+                userInput = "", // 입력창 비움
+                isLoading = true, error = null
+            )
+        }
+
+        viewModelScope.launch {
+            getChatResponseUseCase(GetChatResponseUseCase.Params(inputText))
+                .collectLatest { result ->
+                    when (result) {
+                        is DataResourceResult.Success -> {
+                            val gptMessage = ChatMessageUIModel(
+                                text = result.data.response,
+                                isFromGpt = true
+                            )
+                            _uiState.update {
+                                it.copy(
+                                    messages = it.messages + gptMessage,
+                                    isLoading = false
+                                )
+                            }
+                        }
+
+                        is DataResourceResult.Failure -> {
+                            _uiState.update { it.copy(error = result.exception) }
+                        }
+
+                        DataResourceResult.Loading -> {}
+                        DataResourceResult.DummyConstructor -> {}
+                    }
+                }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update {
+            it.copy(error = null)
+        }
+    }
+}
+
+data class StudyUIState(
+    override val isLoading: Boolean = false,
+    override val error: PayKidsException? = null,
+    val messages: List<ChatMessageUIModel> = listOf(),
+    val userInput: String = ""
+) : UIState()


### PR DESCRIPTION
## 📝작업 내용

> 학습하기 화면 채팅 api 연결

## 작업 상세 내용

- [x] ChatResponseDTO, ChatResponseModel response 타입 수정
- [x] 의존성 수동 주입
- [x] GPT 채팅 응답 기능 구현
- [x] 응답 요청 횟수가 0이 되면 요청할 수 없도록 함
- [x] 사용자 닉네임 로드 구현

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
