### PR TITLE
refactor: 용돈일기 뷰모델와 지출분석 뷰모델 수정

### DIFF
--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -76,7 +76,9 @@ class MainActivity : ComponentActivity() {
                     provider.getExpenseMonthCategoryUseCase,
                     provider.getIncomeMonthCategoryUseCase,
                     provider.deleteExpenseUseCase,
-                    provider.deleteIncomeUseCase
+                    provider.deleteIncomeUseCase,
+                    provider.getExpenseAllCategoryForMonthUseCase,
+                    provider.getIncomeAllCategoryForMonthUseCase
                 )
             }
         }

--- a/app/src/main/java/com/paykidscompose/app/MainActivity.kt
+++ b/app/src/main/java/com/paykidscompose/app/MainActivity.kt
@@ -60,6 +60,8 @@ class MainActivity : ComponentActivity() {
                     provider.getIncomeDayUseCase,
                     provider.getExpenseCategoryListUseCase,
                     provider.getIncomeCategoryListUseCase,
+                    provider.getMonthDailyAmountsUseCase,
+                    provider.getSelectDayTransactionsUseCase,
                     provider.saveExpenseUseCase,
                     provider.saveIncomeUseCase,
                     provider.replaceExpenseUseCase,

--- a/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
+++ b/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
@@ -7,6 +7,7 @@ import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
 import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
@@ -19,6 +20,7 @@ import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUs
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
@@ -173,6 +175,11 @@ class ApplicationContainerImpl(
         ReplaceExpenseUseCase(expenseAllowanceRepository)
     override val replaceIncomeUseCase: ReplaceIncomeUseCase =
         ReplaceIncomeUseCase(incomeAllowanceRepository)
+
+    override val getExpenseAllCategoryForMonthUseCase: GetExpenseAllCategoryForMonthUseCase =
+        GetExpenseAllCategoryForMonthUseCase(expenseAllowanceRepository, expenseCategoryRepository)
+    override val getIncomeAllCategoryForMonthUseCase: GetIncomeAllCategoryForMonthUseCase =
+        GetIncomeAllCategoryForMonthUseCase(incomeAllowanceRepository, incomeCategoryRepository)
 
     override val getExpenseMonthCategoryUseCase: GetExpenseMonthCategoryUseCase =
         GetExpenseMonthCategoryUseCase(expenseAllowanceRepository)

--- a/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
+++ b/app/src/main/java/com/paykidscompose/app/di/ApplicationContainerImpl.kt
@@ -3,6 +3,8 @@ package com.paykidscompose.app.di
 import android.content.Context
 import com.paykidscompose.common.di.ApplicationContainer
 import com.paykidscompose.common.usecase.achievement.GetAchievementsUseCase
+import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
+import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
@@ -122,7 +124,8 @@ class ApplicationContainerImpl(
     override val getCheckAnswerUseCase: GetCheckAnswerUseCase = GetCheckAnswerUseCase(quizRepository)
     override val getCheckStageUseCase: GetCheckStageUseCase = GetCheckStageUseCase(quizRepository)
 
-    override val getAchievementsUseCase: GetAchievementsUseCase = GetAchievementsUseCase(achievementRepository)
+    override val getAchievementsUseCase: GetAchievementsUseCase =
+        GetAchievementsUseCase(achievementRepository)
     override val getQuestsUseCase: GetQuestsUseCase = GetQuestsUseCase(questRepository)
 
     override val getChatResponseUseCase: GetChatResponseUseCase = GetChatResponseUseCase(chatRepository)
@@ -160,6 +163,10 @@ class ApplicationContainerImpl(
         GetExpenseCategoryListUseCase(expenseCategoryRepository)
     override val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase =
         GetIncomeCategoryListUseCase(incomeCategoryRepository)
+    override val getMonthDailyAmountsUseCase: GetMonthDailyAmountsUseCase =
+        GetMonthDailyAmountsUseCase(expenseAllowanceRepository, incomeAllowanceRepository)
+    override val getSelectDayTransactionsUseCase: GetSelectDayTransactionsUseCase =
+        GetSelectDayTransactionsUseCase(expenseAllowanceRepository, incomeAllowanceRepository)
     override val saveExpenseUseCase: SaveExpenseUseCase = SaveExpenseUseCase(expenseAllowanceRepository)
     override val saveIncomeUseCase: SaveIncomeUseCase = SaveIncomeUseCase(incomeAllowanceRepository)
     override val replaceExpenseUseCase: ReplaceExpenseUseCase =

--- a/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
+++ b/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
@@ -5,6 +5,7 @@ import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
 import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
@@ -17,6 +18,7 @@ import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUs
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
@@ -80,6 +82,8 @@ interface ApplicationContainer {
     val getIncomeMonthCategoryUseCase: GetIncomeMonthCategoryUseCase
     val getMonthDailyAmountsUseCase: GetMonthDailyAmountsUseCase
     val getSelectDayTransactionsUseCase: GetSelectDayTransactionsUseCase
+    val getExpenseAllCategoryForMonthUseCase: GetExpenseAllCategoryForMonthUseCase
+    val getIncomeAllCategoryForMonthUseCase: GetIncomeAllCategoryForMonthUseCase
     val saveExpenseUseCase: SaveExpenseUseCase
     val saveIncomeUseCase: SaveIncomeUseCase
     val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase

--- a/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
+++ b/common/src/main/java/com/paykidscompose/common/di/ApplicationContainer.kt
@@ -1,6 +1,8 @@
 package com.paykidscompose.common.di
 
 import com.paykidscompose.common.usecase.achievement.GetAchievementsUseCase
+import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
+import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
@@ -76,6 +78,8 @@ interface ApplicationContainer {
     val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase
     val getExpenseMonthCategoryUseCase: GetExpenseMonthCategoryUseCase
     val getIncomeMonthCategoryUseCase: GetIncomeMonthCategoryUseCase
+    val getMonthDailyAmountsUseCase: GetMonthDailyAmountsUseCase
+    val getSelectDayTransactionsUseCase: GetSelectDayTransactionsUseCase
     val saveExpenseUseCase: SaveExpenseUseCase
     val saveIncomeUseCase: SaveIncomeUseCase
     val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetMonthDailyAmountsUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetMonthDailyAmountsUseCase.kt
@@ -52,7 +52,20 @@ class GetMonthDailyAmountsUseCase(
                         DataResourceResult.Failure(incomeResult.exception)
                     }
 
-                    else -> DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = "알 수 없는 에러 발생"))
+                    expenseResult is DataResourceResult.Loading || incomeResult is DataResourceResult.Loading -> {
+                        DataResourceResult.Loading
+                    }
+
+                    expenseResult is DataResourceResult.DummyConstructor || incomeResult is DataResourceResult.DummyConstructor -> {
+                        DataResourceResult.DummyConstructor
+                    }
+
+                    else -> DataResourceResult.Failure(
+                        PayKidsException.ToastException(
+                            code = -1,
+                            message = "알 수 없는 에러 발생"
+                        )
+                    )
                 }
             }
         } else {

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetMonthDailyAmountsUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetMonthDailyAmountsUseCase.kt
@@ -1,0 +1,69 @@
+package com.paykidscompose.common.usecase.allowance
+
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.repository.ExpenseAllowanceRepository
+import com.paykidscompose.common.repository.IncomeAllowanceRepository
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.base.FlowUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import java.time.LocalDate
+
+class GetMonthDailyAmountsUseCase(
+    private val expenseRepository: ExpenseAllowanceRepository,
+    private val incomeRepository: IncomeAllowanceRepository
+) : FlowUseCase<GetMonthDailyAmountsUseCase.Params, DataResourceResult<Map<LocalDate, Pair<Int, Int>>>>() {
+
+    data class Params(val year: Int, val month: Int)
+
+    override fun execute(params: Params?): Flow<DataResourceResult<Map<LocalDate, Pair<Int, Int>>>> {
+        return if (params != null) {
+            combine(
+                expenseRepository.getExpenseMonthDailyAmount(params.year, params.month),
+                incomeRepository.getIncomeMonthDailyAmount(params.year, params.month)
+            ) { expenseResult, incomeResult ->
+                when {
+                    expenseResult is DataResourceResult.Success && incomeResult is DataResourceResult.Success -> {
+                        val expenseMap = expenseResult.data.groupBy { it.date }
+                            .mapValues { (_, chartAmountModel) ->
+                                chartAmountModel.sumOf { it.amount }
+                            }
+
+                        val incomeMap = incomeResult.data.groupBy { it.date }
+                            .mapValues { (_, chartAmountModel) ->
+                                chartAmountModel.sumOf { it.amount }
+                            }
+
+                        val allDates = (expenseMap.keys + incomeMap.keys).toSet()
+
+                        val resultMap = allDates.associateWith { date ->
+                            Pair(expenseMap[date] ?: 0, incomeMap[date] ?: 0)
+                        }
+
+                        DataResourceResult.Success(resultMap)
+                    }
+
+                    expenseResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(expenseResult.exception)
+                    }
+
+                    incomeResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(incomeResult.exception)
+                    }
+
+                    else -> DataResourceResult.Failure(PayKidsException.ToastException(code = -1, message = "알 수 없는 에러 발생"))
+                }
+            }
+        } else {
+            flowOf(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = "유효하지 않은 달 입니다."
+                    )
+                )
+            )
+        }
+    }
+}

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetSelectDayTransactionsUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetSelectDayTransactionsUseCase.kt
@@ -1,0 +1,60 @@
+package com.paykidscompose.common.usecase.allowance
+
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.model.allowance.AllowanceChartModel
+import com.paykidscompose.common.repository.ExpenseAllowanceRepository
+import com.paykidscompose.common.repository.IncomeAllowanceRepository
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.base.FlowUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import java.time.LocalDate
+
+class GetSelectDayTransactionsUseCase(
+    private val expenseRepository: ExpenseAllowanceRepository,
+    private val incomeRepository: IncomeAllowanceRepository
+) : FlowUseCase<GetSelectDayTransactionsUseCase.Params, DataResourceResult<List<AllowanceChartModel>>>() {
+
+    override fun execute(params: Params?): Flow<DataResourceResult<List<AllowanceChartModel>>> {
+        return if (params != null) {
+            combine(
+                expenseRepository.getExpenseDay(params.localDate),
+                incomeRepository.getIncomeDay(params.localDate)
+            ) { expenseResult, incomeResult ->
+                when {
+                    expenseResult is DataResourceResult.Success && incomeResult is DataResourceResult.Success -> {
+                        DataResourceResult.Success(
+                            (expenseResult.data + incomeResult.data)
+                                .sortedByDescending { it.date })
+                    }
+
+                    expenseResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(expenseResult.exception)
+                    }
+
+                    incomeResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(incomeResult.exception)
+                    }
+
+                    else -> {
+                        DataResourceResult.Success(emptyList())
+                    }
+                }
+            }
+        } else {
+            flowOf(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = "내역을 확인 하고 싶은 날짜를 제대로 선택하세요."
+                    )
+                )
+            )
+        }
+    }
+
+    data class Params(
+        val localDate: LocalDate
+    )
+}

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetSelectDayTransactionsUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/GetSelectDayTransactionsUseCase.kt
@@ -37,6 +37,14 @@ class GetSelectDayTransactionsUseCase(
                         DataResourceResult.Failure(incomeResult.exception)
                     }
 
+                    expenseResult is DataResourceResult.Loading || incomeResult is DataResourceResult.Loading -> {
+                        DataResourceResult.Loading
+                    }
+
+                    expenseResult is DataResourceResult.DummyConstructor || incomeResult is DataResourceResult.DummyConstructor -> {
+                        DataResourceResult.DummyConstructor
+                    }
+
                     else -> {
                         DataResourceResult.Success(emptyList())
                     }

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/expense/GetExpenseAllCategoryForMonthUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/expense/GetExpenseAllCategoryForMonthUseCase.kt
@@ -1,0 +1,80 @@
+package com.paykidscompose.common.usecase.allowance.expense
+
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.model.allowance.AllowanceChartCategoryModel
+import com.paykidscompose.common.repository.ExpenseAllowanceRepository
+import com.paykidscompose.common.repository.ExpenseCategoryRepository
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.base.FlowUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+
+class GetExpenseAllCategoryForMonthUseCase(
+    private val allowanceRepository: ExpenseAllowanceRepository,
+    private val categoryRepository: ExpenseCategoryRepository
+) : FlowUseCase<GetExpenseAllCategoryForMonthUseCase.Params, DataResourceResult<List<AllowanceChartCategoryModel>>>() {
+    override fun execute(params: Params?): Flow<DataResourceResult<List<AllowanceChartCategoryModel>>> {
+        return if (params != null) {
+            combine(
+                categoryRepository.getExpenseCategoryList(),
+                allowanceRepository.getExpenseMonthAllCategory(params.year, params.month)
+            ) { categoryResult, monthResult ->
+                when {
+                    categoryResult is DataResourceResult.Success && monthResult is DataResourceResult.Success -> {
+                        val merge = categoryResult.data.map { category ->
+                            val match = monthResult.data.find { it.category == category.title }
+                            AllowanceChartCategoryModel(
+                                category = category.title,
+                                type = category.type,
+                                amount = match?.amount ?: 0,
+                                percent = match?.percent ?: 0
+                            )
+                        }
+
+                        DataResourceResult.Success(merge)
+                    }
+
+                    categoryResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(categoryResult.exception)
+                    }
+
+                    monthResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(monthResult.exception)
+                    }
+
+                    categoryResult is DataResourceResult.Loading || monthResult is DataResourceResult.Loading -> {
+                        DataResourceResult.Loading
+                    }
+
+                    categoryResult is DataResourceResult.DummyConstructor || monthResult is DataResourceResult.DummyConstructor -> {
+                        DataResourceResult.DummyConstructor
+                    }
+
+                    else -> {
+                        DataResourceResult.Failure(
+                            PayKidsException.ToastException(
+                                code = -1,
+                                message = "알 수 없는 에러 발생"
+                            )
+                        )
+                    }
+                }
+            }
+        } else {
+            flowOf(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = "조회할 달이 유효하지 않습니다."
+                    )
+                )
+            )
+        }
+    }
+
+    data class Params(
+        val year: Int,
+        val month: Int
+    )
+}

--- a/common/src/main/java/com/paykidscompose/common/usecase/allowance/income/GetIncomeAllCategoryForMonthUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/allowance/income/GetIncomeAllCategoryForMonthUseCase.kt
@@ -1,0 +1,81 @@
+package com.paykidscompose.common.usecase.allowance.income
+
+import com.paykidscompose.common.exception.PayKidsException
+import com.paykidscompose.common.model.allowance.AllowanceChartCategoryModel
+import com.paykidscompose.common.repository.IncomeAllowanceRepository
+import com.paykidscompose.common.repository.IncomeCategoryRepository
+import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.base.FlowUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+
+class GetIncomeAllCategoryForMonthUseCase(
+    private val allowanceRepository: IncomeAllowanceRepository,
+    private val categoryRepository: IncomeCategoryRepository
+) : FlowUseCase<GetIncomeAllCategoryForMonthUseCase.Params, DataResourceResult<List<AllowanceChartCategoryModel>>>() {
+    override fun execute(params: Params?): Flow<DataResourceResult<List<AllowanceChartCategoryModel>>> {
+        return if (params != null) {
+            combine(
+                categoryRepository.getIncomeCategoryList(),
+                allowanceRepository.getIncomeMonthAllCategory(params.year, params.month)
+            ) { categoryResult, monthResult ->
+                when {
+                    categoryResult is DataResourceResult.Success && monthResult is DataResourceResult.Success -> {
+                        val merge = categoryResult.data.map { category ->
+                            val match = monthResult.data.find { it.category == category.title }
+                            AllowanceChartCategoryModel(
+                                category = category.title,
+                                type = category.type,
+                                amount = match?.amount ?: 0,
+                                percent = match?.percent ?: 0
+                            )
+                        }
+
+                        DataResourceResult.Success(merge)
+                    }
+
+                    categoryResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(categoryResult.exception)
+                    }
+
+                    monthResult is DataResourceResult.Failure -> {
+                        DataResourceResult.Failure(monthResult.exception)
+                    }
+
+                    categoryResult is DataResourceResult.Loading || monthResult is DataResourceResult.Loading -> {
+                        DataResourceResult.Loading
+                    }
+
+                    categoryResult is DataResourceResult.DummyConstructor || monthResult is DataResourceResult.DummyConstructor -> {
+                        DataResourceResult.DummyConstructor
+                    }
+
+                    else -> {
+                        DataResourceResult.Failure(
+                            PayKidsException.ToastException(
+                                code = -1,
+                                message = "알 수 없는 에러 발생"
+                            )
+                        )
+                    }
+                }
+            }
+        } else {
+            flowOf(
+                DataResourceResult.Failure(
+                    PayKidsException.ToastException(
+                        code = -1,
+                        message = "조회할 달이 유효하지 않습니다."
+                    )
+                )
+            )
+        }
+    }
+
+
+    data class Params(
+        val year: Int,
+        val month: Int
+    )
+}

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/AllowanceDiaryViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/AllowanceDiaryViewModelFactory.kt
@@ -2,16 +2,14 @@ package com.paykidscompose.presentation.factory
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
+import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthMostCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.ReplaceExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.ReplaceIncomeUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeUseCase
 import com.paykidscompose.presentation.screen.allowance.AllowanceDiaryViewModel
@@ -19,12 +17,10 @@ import com.paykidscompose.presentation.screen.allowance.AllowanceDiaryViewModel
 class AllowanceDiaryViewModelFactory(
     private val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
     private val getExpenseMonthMostCategoryUseCase: GetExpenseMonthMostCategoryUseCase,
-    private val getExpenseMonthDailyAmountUseCase: GetExpenseMonthDailyAmountUseCase,
-    private val getIncomeMonthDailyAmountUseCase: GetIncomeMonthDailyAmountUseCase,
-    private val getExpenseDayUseCase: GetExpenseDayUseCase,
-    private val getIncomeDayUseCase: GetIncomeDayUseCase,
     private val getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
     private val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
+    private val getMonthDailyAmountsUseCase: GetMonthDailyAmountsUseCase,
+    private val getSelectDayTransactionsUseCase: GetSelectDayTransactionsUseCase,
     private val saveExpenseUseCase: SaveExpenseUseCase,
     private val saveIncomeUseCase: SaveIncomeUseCase,
     private val replaceExpenseUseCase: ReplaceExpenseUseCase,
@@ -36,12 +32,10 @@ class AllowanceDiaryViewModelFactory(
             return AllowanceDiaryViewModel(
                 getExpenseMonthTotalAmountUseCase,
                 getExpenseMonthMostCategoryUseCase,
-                getExpenseMonthDailyAmountUseCase,
-                getIncomeMonthDailyAmountUseCase,
-                getExpenseDayUseCase,
-                getIncomeDayUseCase,
                 getExpenseCategoryListUseCase,
                 getIncomeCategoryListUseCase,
+                getMonthDailyAmountsUseCase,
+                getSelectDayTransactionsUseCase,
                 saveExpenseUseCase,
                 saveIncomeUseCase,
                 replaceExpenseUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/factory/TransactionAnalysisViewModelFactory.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/factory/TransactionAnalysisViewModelFactory.kt
@@ -3,13 +3,11 @@ package com.paykidscompose.presentation.factory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
 import com.paykidscompose.presentation.screen.allowance.analysis.TransactionAnalysisViewModel
@@ -17,10 +15,8 @@ import com.paykidscompose.presentation.screen.allowance.analysis.TransactionAnal
 class TransactionAnalysisViewModelFactory(
     private val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
     private val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
-    private val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
-    private val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
-    private val getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
-    private val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
+    private val getExpenseAllCategoryForMonthUseCase: GetExpenseAllCategoryForMonthUseCase,
+    private val getIncomeAllCategoryForMonthUseCase: GetIncomeAllCategoryForMonthUseCase,
     private val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
     private val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
     private val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
@@ -32,10 +28,8 @@ class TransactionAnalysisViewModelFactory(
             return TransactionAnalysisViewModel(
                 getExpenseMonthTotalAmountUseCase,
                 getIncomeMonthTotalAmountUseCase,
-                getExpenseMonthAllCategoryUseCase,
-                getIncomeMonthAllCategoryUseCase,
-                getExpenseCategoryListUseCase,
-                getIncomeCategoryListUseCase,
+                getExpenseAllCategoryForMonthUseCase,
+                getIncomeAllCategoryForMonthUseCase,
                 deleteExpenseCategoryUseCase,
                 deleteIncomeCategoryUseCase,
                 saveExpenseCategoryUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -22,6 +22,7 @@ import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
 import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
@@ -34,6 +35,7 @@ import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUs
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
@@ -150,7 +152,9 @@ fun PayKidsApp(
     getExpenseMonthCategoryUseCase: GetExpenseMonthCategoryUseCase,
     getIncomeMonthCategoryUseCase: GetIncomeMonthCategoryUseCase,
     deleteExpenseUseCase: DeleteExpenseUseCase,
-    deleteIncomeUseCase: DeleteIncomeUseCase
+    deleteIncomeUseCase: DeleteIncomeUseCase,
+    getExpenseAllCategoryForMonthUseCase: GetExpenseAllCategoryForMonthUseCase,
+    getIncomeAllCategoryForMonthUseCase: GetIncomeAllCategoryForMonthUseCase
 ) {
     val navController: NavHostController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -404,10 +408,8 @@ fun PayKidsApp(
                     factory = TransactionAnalysisViewModelFactory(
                         getExpenseMonthTotalAmountUseCase,
                         getIncomeMonthTotalAmountUseCase,
-                        getExpenseMonthAllCategoryUseCase,
-                        getIncomeMonthAllCategoryUseCase,
-                        getExpenseCategoryListUseCase,
-                        getIncomeCategoryListUseCase,
+                        getExpenseAllCategoryForMonthUseCase,
+                        getIncomeAllCategoryForMonthUseCase,
                         deleteExpenseCategoryUseCase,
                         deleteIncomeCategoryUseCase,
                         saveExpenseCategoryUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -18,6 +18,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.paykidscompose.common.enums.EntryPoint
 import com.paykidscompose.common.usecase.achievement.GetAchievementsUseCase
+import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
+import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
@@ -132,6 +134,8 @@ fun PayKidsApp(
     getIncomeDayUseCase: GetIncomeDayUseCase,
     getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
     getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
+    getMonthDailyAmountsUseCase: GetMonthDailyAmountsUseCase,
+    getSelectDayTransactionsUseCase: GetSelectDayTransactionsUseCase,
     saveExpenseUseCase: SaveExpenseUseCase,
     saveIncomeUseCase: SaveIncomeUseCase,
     replaceExpenseUseCase: ReplaceExpenseUseCase,
@@ -376,12 +380,10 @@ fun PayKidsApp(
                     factory = AllowanceDiaryViewModelFactory(
                         getExpenseMonthTotalAmountUseCase,
                         getExpenseMonthMostCategoryUseCase,
-                        getExpenseMonthDailyAmountUseCase,
-                        getIncomeMonthDailyAmountUseCase,
-                        getExpenseDayUseCase,
-                        getIncomeDayUseCase,
                         getExpenseCategoryListUseCase,
                         getIncomeCategoryListUseCase,
+                        getMonthDailyAmountsUseCase,
+                        getSelectDayTransactionsUseCase,
                         saveExpenseUseCase,
                         saveIncomeUseCase,
                         replaceExpenseUseCase,

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/allowance/AllowanceDiaryViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/allowance/AllowanceDiaryViewModel.kt
@@ -5,22 +5,19 @@ import androidx.lifecycle.viewModelScope
 import com.paykidscompose.common.enums.AllowanceType
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.result.DataResourceResult
+import com.paykidscompose.common.usecase.allowance.GetMonthDailyAmountsUseCase
+import com.paykidscompose.common.usecase.allowance.GetSelectDayTransactionsUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseDayUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthMostCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.ReplaceExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeDayUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthDailyAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.ReplaceIncomeUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeUseCase
 import com.paykidscompose.common.util.today
 import com.paykidscompose.presentation.base.UIEvent
 import com.paykidscompose.presentation.base.UIState
-import com.paykidscompose.presentation.mapper.allowance.AllowanceChartAmountUIModelMapper
 import com.paykidscompose.presentation.mapper.allowance.AllowanceChartCategoryUIModelMapper
 import com.paykidscompose.presentation.mapper.allowance.AllowanceChartUIModelMapper
 import com.paykidscompose.presentation.mapper.allowance.CategoryUIModelMapper
@@ -32,7 +29,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -40,12 +36,10 @@ import java.time.LocalDate
 class AllowanceDiaryViewModel(
     private val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
     private val getExpenseMonthMostCategoryUseCase: GetExpenseMonthMostCategoryUseCase,
-    private val getExpenseMonthDailyAmountUseCase: GetExpenseMonthDailyAmountUseCase,
-    private val getIncomeMonthDailyAmountUseCase: GetIncomeMonthDailyAmountUseCase,
-    private val getExpenseDayUseCase: GetExpenseDayUseCase,
-    private val getIncomeDayUseCase: GetIncomeDayUseCase,
     private val getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
     private val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
+    private val getMonthDailyAmountsUseCase: GetMonthDailyAmountsUseCase,
+    private val getSelectDayTransactionsUseCase: GetSelectDayTransactionsUseCase,
     private val saveExpenseUseCase: SaveExpenseUseCase,
     private val saveIncomeUseCase: SaveIncomeUseCase,
     private val replaceExpenseUseCase: ReplaceExpenseUseCase,
@@ -62,7 +56,10 @@ class AllowanceDiaryViewModel(
             val newMonth = it.currentMonth.minusMonths(1)
             it.copy(currentMonth = newMonth)
         }
-        load()
+
+        viewModelScope.launch {
+            load()
+        }
     }
 
     fun onNextMonth() {
@@ -70,7 +67,9 @@ class AllowanceDiaryViewModel(
             val newMonth = it.currentMonth.plusMonths(1)
             it.copy(currentMonth = newMonth)
         }
-        load()
+        viewModelScope.launch {
+            load()
+        }
     }
 
     fun onSelectedDate(date: LocalDate) {
@@ -99,12 +98,13 @@ class AllowanceDiaryViewModel(
             )
         }
 
-        when (chartUIModel.type) {
-            AllowanceType.EXPENSE -> replaceExpense(chartUIModel)
-            AllowanceType.INCOME -> replaceIncome(chartUIModel)
+        viewModelScope.launch {
+            when (chartUIModel.type) {
+                AllowanceType.EXPENSE -> replaceExpense(chartUIModel)
+                AllowanceType.INCOME -> replaceIncome(chartUIModel)
+            }
+            load()
         }
-
-        load()
     }
 
     fun onDismissReplaceDialog() {
@@ -133,12 +133,13 @@ class AllowanceDiaryViewModel(
             )
         }
 
-        when (chartUIModel.type) {
-            AllowanceType.EXPENSE -> saveExpense(chartUIModel)
-            AllowanceType.INCOME -> saveIncome(chartUIModel)
+        viewModelScope.launch {
+            when (chartUIModel.type) {
+                AllowanceType.EXPENSE -> saveExpense(chartUIModel)
+                AllowanceType.INCOME -> saveIncome(chartUIModel)
+            }
+            load()
         }
-
-        load()
     }
 
     fun onDismissAddDialog() {
@@ -149,148 +150,115 @@ class AllowanceDiaryViewModel(
         }
     }
 
-    fun load() {
-        viewModelScope.launch {
-            getMonthTotalAmountExpense()
-            getMonthMostCategoryExpense()
-            getMonthDailyAmounts()
-        }
-    }
-
-    private fun saveIncome(chartUIModel: AllowanceChartUIModel) {
-        viewModelScope.launch {
-            val result = saveIncomeUseCase(
-                SaveIncomeUseCase.Params(
-                    AllowanceChartUIModelMapper.mapToModel(
-                        chartUIModel
-                    )
-                )
-            )
-
-            when (result) {
-                DataResourceResult.DummyConstructor -> {}
-                is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            error = result.exception
-                        )
-                    }
-                }
-
-                DataResourceResult.Loading -> {}
-                is DataResourceResult.Success -> {
-                    _uiEvent.emit(UIEvent.SuccessShowToast("수입 내역이 저장되었습니다!"))
-                }
-            }
-        }
-    }
-
-    private fun saveExpense(chartUIModel: AllowanceChartUIModel) {
-        viewModelScope.launch {
-            val result = saveExpenseUseCase(
-                SaveExpenseUseCase.Params(
-                    AllowanceChartUIModelMapper.mapToModel(
-                        chartUIModel
-                    )
-                )
-            )
-
-            when (result) {
-                DataResourceResult.DummyConstructor -> {}
-                is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            error = result.exception
-                        )
-                    }
-                }
-
-                DataResourceResult.Loading -> {}
-                is DataResourceResult.Success -> {
-                    _uiEvent.emit(UIEvent.SuccessShowToast("소비 내역이 저장되었습니다!"))
-                }
-            }
-        }
-    }
-
-    private fun replaceIncome(chartUIModel: AllowanceChartUIModel) {
-        viewModelScope.launch {
-            val result = replaceIncomeUseCase(
-                ReplaceIncomeUseCase.Params(
-                    AllowanceChartUIModelMapper.mapToModel(
-                        chartUIModel
-                    )
-                )
-            )
-
-            when (result) {
-                is DataResourceResult.Success -> {
-                    _uiEvent.emit(UIEvent.SuccessShowToast("수입 내역이 수정되었습니다!"))
-                }
-
-                is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            error = result.exception
-                        )
-                    }
-                }
-
-                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
-            }
-        }
-    }
-
-    private fun replaceExpense(chartUIModel: AllowanceChartUIModel) {
-        viewModelScope.launch {
-            val result = replaceExpenseUseCase(
-                ReplaceExpenseUseCase.Params(
-                    AllowanceChartUIModelMapper.mapToModel(
-                        chartUIModel
-                    )
-                )
-            )
-
-            when (result) {
-                is DataResourceResult.Success -> {
-                    _uiEvent.emit(UIEvent.SuccessShowToast("소비 내역이 수정되었습니다!"))
-                }
-
-                is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = result.exception
-                        )
-                    }
-                }
-
-                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
-            }
-        }
-    }
-
-    private suspend fun getMonthTotalAmountExpense() {
+    suspend fun load() {
         _uiState.update {
-            it.copy(isLoading = true)
+            it.copy(
+                isLoading = true
+            )
         }
+        getMonthTotalAmountExpense()
+        getMonthMostCategoryExpense()
+        getMonthDailyAmounts()
+        _uiState.update {
+            it.copy(
+                isLoading = false
+            )
+        }
+    }
 
-        val result = getExpenseMonthTotalAmountUseCase(
-            GetExpenseMonthTotalAmountUseCase.Params(
-                _uiState.value.currentMonth.year,
-                _uiState.value.currentMonth.monthValue
+    private suspend fun saveIncome(chartUIModel: AllowanceChartUIModel) {
+        val result = saveIncomeUseCase(
+            SaveIncomeUseCase.Params(
+                AllowanceChartUIModelMapper.mapToModel(
+                    chartUIModel
+                )
             )
         )
+
         when (result) {
-            is DataResourceResult.Success -> {
+            DataResourceResult.DummyConstructor -> {}
+            is DataResourceResult.Failure -> {
                 _uiState.update {
                     it.copy(
-                        isLoading = false,
-                        uiModel = it.uiModel.copy(
-                            headerTotalExpense = formatAmount(result.data)
-                        )
+                        error = result.exception
                     )
                 }
+            }
+
+            DataResourceResult.Loading -> {}
+            is DataResourceResult.Success -> {
+                _uiEvent.emit(UIEvent.SuccessShowToast("수입 내역이 저장되었습니다!"))
+            }
+        }
+
+    }
+
+    private suspend fun saveExpense(chartUIModel: AllowanceChartUIModel) {
+        val result = saveExpenseUseCase(
+            SaveExpenseUseCase.Params(
+                AllowanceChartUIModelMapper.mapToModel(
+                    chartUIModel
+                )
+            )
+        )
+
+        when (result) {
+            DataResourceResult.DummyConstructor -> {}
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        error = result.exception
+                    )
+                }
+            }
+
+            DataResourceResult.Loading -> {}
+            is DataResourceResult.Success -> {
+                _uiEvent.emit(UIEvent.SuccessShowToast("소비 내역이 저장되었습니다!"))
+            }
+
+        }
+    }
+
+    private suspend fun replaceIncome(chartUIModel: AllowanceChartUIModel) {
+        val result = replaceIncomeUseCase(
+            ReplaceIncomeUseCase.Params(
+                AllowanceChartUIModelMapper.mapToModel(
+                    chartUIModel
+                )
+            )
+        )
+
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiEvent.emit(UIEvent.SuccessShowToast("수입 내역이 수정되었습니다!"))
+            }
+
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        error = result.exception
+                    )
+                }
+            }
+
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+        }
+
+    }
+
+    private suspend fun replaceExpense(chartUIModel: AllowanceChartUIModel) {
+        val result = replaceExpenseUseCase(
+            ReplaceExpenseUseCase.Params(
+                AllowanceChartUIModelMapper.mapToModel(
+                    chartUIModel
+                )
+            )
+        )
+
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiEvent.emit(UIEvent.SuccessShowToast("소비 내역이 수정되었습니다!"))
             }
 
             is DataResourceResult.Failure -> {
@@ -302,16 +270,42 @@ class AllowanceDiaryViewModel(
                 }
             }
 
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+        }
+    }
+
+    private suspend fun getMonthTotalAmountExpense() {
+        val result = getExpenseMonthTotalAmountUseCase(
+            GetExpenseMonthTotalAmountUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue
+            )
+        )
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiState.update {
+                    it.copy(
+                        uiModel = it.uiModel.copy(
+                            headerTotalExpense = formatAmount(result.data)
+                        )
+                    )
+                }
+            }
+
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        error = result.exception
+                    )
+                }
+            }
+
             DataResourceResult.Loading, DataResourceResult.DummyConstructor -> {}
         }
 
     }
 
     private suspend fun getMonthMostCategoryExpense() {
-        _uiState.update {
-            it.copy(isLoading = true)
-        }
-
         getExpenseMonthMostCategoryUseCase(
             GetExpenseMonthMostCategoryUseCase.Params(
                 _uiState.value.currentMonth.year,
@@ -326,7 +320,6 @@ class AllowanceDiaryViewModel(
                             AllowanceChartCategoryUIModelMapper.mapToLayerModel(mostCategoryExpense)
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
                                 uiModel = it.uiModel.copy(
                                     mostCategoryExpense = layerModel
                                 )
@@ -335,7 +328,6 @@ class AllowanceDiaryViewModel(
                     } else {
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
                                 uiModel = it.uiModel.copy(
                                     mostCategoryExpense = null
                                 )
@@ -346,130 +338,83 @@ class AllowanceDiaryViewModel(
 
                 is DataResourceResult.Failure -> {
                     _uiState.update {
-                        it.copy(isLoading = false, error = result.exception)
+                        it.copy(error = result.exception)
                     }
                 }
 
-                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {
-                    _uiState.update {
-                        it.copy(isLoading = true)
-                    }
-                }
+                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
             }
         }
     }
 
     private suspend fun getMonthDailyAmounts() {
-        _uiState.update {
-            it.copy(isLoading = true)
-        }
-
-        val year = _uiState.value.currentMonth.year
-        val month = _uiState.value.currentMonth.monthValue
-
-        combine(
-            getExpenseMonthDailyAmountUseCase(
-                GetExpenseMonthDailyAmountUseCase.Params(year, month)
-            ),
-            getIncomeMonthDailyAmountUseCase(
-                GetIncomeMonthDailyAmountUseCase.Params(year, month)
+        getMonthDailyAmountsUseCase(
+            GetMonthDailyAmountsUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue
             )
-        ) { expenseResult, incomeResult ->
-            Pair(expenseResult, incomeResult)
-        }.collect { (expenseResult, incomeResult) ->
-            when {
-                expenseResult is DataResourceResult.Success && incomeResult is DataResourceResult.Success -> {
-                    val expenseList =
-                        expenseResult.data.map { AllowanceChartAmountUIModelMapper.mapToLayerModel(it) }
-                    val incomeList =
-                        incomeResult.data.map { AllowanceChartAmountUIModelMapper.mapToLayerModel(it) }
-
-                    val expenseMap = expenseList.groupBy { it.date }
-                        .mapValues { (_, chartAmountUIModel) ->
-                            chartAmountUIModel.sumOf { it.amount }
-                        }
-
-                    val incomeMap = incomeList.groupBy { it.date }
-                        .mapValues { (_, chartAmountUIModel) ->
-                            chartAmountUIModel.sumOf { it.amount }
-                        }
-
-                    val allDates = (expenseMap.keys + incomeMap.keys).toSet()
-
-                    val resultMap = allDates.associateWith { date ->
-                        Pair(expenseMap[date] ?: 0, incomeMap[date] ?: 0)
-                    }
-
+        ).collectLatest { result ->
+            when (result) {
+                is DataResourceResult.Success -> {
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
                             uiModel = it.uiModel.copy(
-                                monthlyDailyAmounts = resultMap
+                                monthlyDailyAmounts = result.data
                             )
                         )
                     }
                 }
 
-                expenseResult is DataResourceResult.Failure -> {
+                is DataResourceResult.Failure -> {
                     _uiState.update {
-                        it.copy(isLoading = false, error = expenseResult.exception)
+                        it.copy(
+                            error = result.exception
+                        )
                     }
                 }
 
-                incomeResult is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(isLoading = false, error = incomeResult.exception)
-                    }
-                }
+                else -> {}
             }
         }
     }
 
     private fun getSelectedDayTransactions() {
-        _uiState.update {
-            it.copy(isLoading = true)
-        }
-
         viewModelScope.launch {
-            combine(
-                getExpenseDayUseCase(
-                    GetExpenseDayUseCase.Params(_uiState.value.selectedDate)
-                ),
-                getIncomeDayUseCase(
-                    GetIncomeDayUseCase.Params(_uiState.value.selectedDate)
+            getSelectDayTransactionsUseCase(
+                GetSelectDayTransactionsUseCase.Params(
+                    _uiState.value.selectedDate
                 )
-            ) { expenseResult, incomeResult ->
-                if (expenseResult is DataResourceResult.Success && incomeResult is DataResourceResult.Success) {
-                    val combineList = expenseResult.data + incomeResult.data
-                    combineList.map { AllowanceChartUIModelMapper.mapToLayerModel(it) }
-                        .sortedByDescending { it.date }
-                } else {
-                    emptyList()
-                }
-            }.collect { list ->
-                _uiState.update {
-                    it.copy(
-                        uiModel = it.uiModel.copy(
-                            selectedDayTransactions = list
-                        )
-                    )
+            ).collectLatest { result ->
+                when (result) {
+                    is DataResourceResult.Success -> {
+                        if (result.data.isNotEmpty()) {
+                            val chartUIModels =
+                                result.data.map { AllowanceChartUIModelMapper.mapToLayerModel(it) }
+                            _uiState.update {
+                                it.copy(
+                                    uiModel = it.uiModel.copy(
+                                        selectedDayTransactions = chartUIModels
+                                    )
+                                )
+                            }
+                        }
+                    }
+
+                    is DataResourceResult.Failure -> {
+                        _uiState.update {
+                            it.copy(
+                                error = result.exception
+                            )
+                        }
+                    }
+
+                    else -> {}
                 }
             }
-        }
-
-        _uiState.update {
-            it.copy(
-                isLoading = false
-            )
         }
     }
 
     fun getExpenseCategoryList() {
-        _uiState.update {
-            it.copy(
-                isLoading = true
-            )
-        }
         viewModelScope.launch {
             getExpenseCategoryListUseCase().collectLatest { result ->
                 when (result) {
@@ -477,7 +422,6 @@ class AllowanceDiaryViewModel(
                         val categories = result.data.map { CategoryUIModelMapper.mapToLayerModel(it) }
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
                                 uiModel = it.uiModel.copy(
                                     expenseCategories = categories
                                 )
@@ -488,22 +432,14 @@ class AllowanceDiaryViewModel(
                     is DataResourceResult.Failure -> {
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
                                 error = result.exception
                             )
                         }
                     }
 
-                    DataResourceResult.DummyConstructor -> {
-                    }
+                    DataResourceResult.DummyConstructor -> {}
 
-                    DataResourceResult.Loading -> {
-                        _uiState.update {
-                            it.copy(
-                                isLoading = true
-                            )
-                        }
-                    }
+                    DataResourceResult.Loading -> {}
                 }
             }
         }
@@ -511,12 +447,6 @@ class AllowanceDiaryViewModel(
     }
 
     fun getIncomeCategoryList() {
-        _uiState.update {
-            it.copy(
-                isLoading = true
-            )
-        }
-
         viewModelScope.launch {
             getIncomeCategoryListUseCase().collectLatest { result ->
                 when (result) {
@@ -524,7 +454,6 @@ class AllowanceDiaryViewModel(
                         val categories = result.data.map { CategoryUIModelMapper.mapToLayerModel(it) }
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
                                 uiModel = it.uiModel.copy(
                                     incomeCategories = categories
                                 )
@@ -535,7 +464,6 @@ class AllowanceDiaryViewModel(
                     is DataResourceResult.Failure -> {
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
                                 error = result.exception
                             )
                         }
@@ -544,13 +472,7 @@ class AllowanceDiaryViewModel(
                     DataResourceResult.DummyConstructor -> {
                     }
 
-                    DataResourceResult.Loading -> {
-                        _uiState.update {
-                            it.copy(
-                                isLoading = true
-                            )
-                        }
-                    }
+                    DataResourceResult.Loading -> {}
                 }
             }
         }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/allowance/analysis/TransactionAnalysisViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/allowance/analysis/TransactionAnalysisViewModel.kt
@@ -6,28 +6,23 @@ import com.paykidscompose.common.enums.AllowanceType
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.allowance.expense.DeleteExpenseCategoryUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.expense.GetExpenseAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.expense.GetExpenseMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.expense.SaveExpenseCategoryUseCase
 import com.paykidscompose.common.usecase.allowance.income.DeleteIncomeCategoryUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeCategoryListUseCase
-import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthAllCategoryUseCase
+import com.paykidscompose.common.usecase.allowance.income.GetIncomeAllCategoryForMonthUseCase
 import com.paykidscompose.common.usecase.allowance.income.GetIncomeMonthTotalAmountUseCase
 import com.paykidscompose.common.usecase.allowance.income.SaveIncomeCategoryUseCase
 import com.paykidscompose.common.util.today
 import com.paykidscompose.presentation.base.UIEvent
 import com.paykidscompose.presentation.base.UIState
 import com.paykidscompose.presentation.mapper.allowance.AllowanceChartCategoryUIModelMapper
-import com.paykidscompose.presentation.mapper.allowance.CategoryUIModelMapper
-import com.paykidscompose.presentation.model.allowance.AllowanceChartCategoryUIModel
 import com.paykidscompose.presentation.model.allowance.TransactionAnalysisUIModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -35,10 +30,8 @@ import java.time.LocalDate
 class TransactionAnalysisViewModel(
     private val getExpenseMonthTotalAmountUseCase: GetExpenseMonthTotalAmountUseCase,
     private val getIncomeMonthTotalAmountUseCase: GetIncomeMonthTotalAmountUseCase,
-    private val getExpenseMonthAllCategoryUseCase: GetExpenseMonthAllCategoryUseCase,
-    private val getIncomeMonthAllCategoryUseCase: GetIncomeMonthAllCategoryUseCase,
-    private val getExpenseCategoryListUseCase: GetExpenseCategoryListUseCase,
-    private val getIncomeCategoryListUseCase: GetIncomeCategoryListUseCase,
+    private val getExpenseAllCategoryForMonthUseCase: GetExpenseAllCategoryForMonthUseCase,
+    private val getIncomeAllCategoryForMonthUseCase: GetIncomeAllCategoryForMonthUseCase,
     private val deleteExpenseCategoryUseCase: DeleteExpenseCategoryUseCase,
     private val deleteIncomeCategoryUseCase: DeleteIncomeCategoryUseCase,
     private val saveExpenseCategoryUseCase: SaveExpenseCategoryUseCase,
@@ -102,7 +95,7 @@ class TransactionAnalysisViewModel(
     }
 
     fun exitDeleteMode() {
-        if(_uiState.value.selectedCategoryForDelete.isNotEmpty()) {
+        if (_uiState.value.selectedCategoryForDelete.isNotEmpty()) {
             viewModelScope.launch {
                 when (_uiState.value.selectedType) {
                     AllowanceType.INCOME -> {
@@ -167,17 +160,17 @@ class TransactionAnalysisViewModel(
     }
 
     fun confirmAddCategory() {
-        when (_uiState.value.selectedType) {
-            AllowanceType.INCOME -> {
-                saveIncomeCategory()
-            }
+        viewModelScope.launch {
+            when (_uiState.value.selectedType) {
+                AllowanceType.INCOME -> {
+                    saveIncomeCategory()
+                }
 
-            AllowanceType.EXPENSE -> {
-                saveExpenseCategory()
+                AllowanceType.EXPENSE -> {
+                    saveExpenseCategory()
+                }
             }
         }
-
-        load()
     }
 
     private suspend fun deleteExpenseCategory() {
@@ -256,80 +249,82 @@ class TransactionAnalysisViewModel(
         }
     }
 
-    private fun saveExpenseCategory() {
+    private suspend fun saveExpenseCategory() {
         if (!_uiState.value.isAddCategory) return
 
-        viewModelScope.launch {
-            val result = saveExpenseCategoryUseCase(
-                SaveExpenseCategoryUseCase.Params(
-                    _uiState.value.category
-                )
+        val result = saveExpenseCategoryUseCase(
+            SaveExpenseCategoryUseCase.Params(
+                _uiState.value.category
             )
+        )
 
-            when (result) {
-                is DataResourceResult.Success -> {
-                    _uiState.update {
-                        it.copy(
-                            isAddCategory = false,
-                            category = ""
-                        )
-                    }
-
-                    _uiEvent.emit(UIEvent.SuccessShowToast("소비 카테고리를 저장했습니다!"))
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiState.update {
+                    it.copy(
+                        isAddCategory = false,
+                        category = ""
+                    )
                 }
 
-                is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = result.exception,
-                            category = "",
-                            isAddCategory = false
-                        )
-                    }
-                }
+                _uiEvent.emit(UIEvent.SuccessShowToast("소비 카테고리를 저장했습니다!"))
 
-                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+                load()
             }
+
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = result.exception,
+                        category = "",
+                        isAddCategory = false
+                    )
+                }
+            }
+
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
         }
+
     }
 
-    private fun saveIncomeCategory() {
+    private suspend fun saveIncomeCategory() {
         if (!_uiState.value.isAddCategory) return
 
-        viewModelScope.launch {
-            val result = saveIncomeCategoryUseCase(
-                SaveIncomeCategoryUseCase.Params(
-                    _uiState.value.category
-                )
+        val result = saveIncomeCategoryUseCase(
+            SaveIncomeCategoryUseCase.Params(
+                _uiState.value.category
             )
+        )
 
-            when (result) {
-                is DataResourceResult.Success -> {
-                    _uiState.update {
-                        it.copy(
-                            isAddCategory = false,
-                            category = ""
-                        )
-                    }
-
-                    _uiEvent.emit(UIEvent.SuccessShowToast("수입 카테고리를 저장했습니다!"))
+        when (result) {
+            is DataResourceResult.Success -> {
+                _uiState.update {
+                    it.copy(
+                        isAddCategory = false,
+                        category = ""
+                    )
                 }
 
-                is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = result.exception,
-                            category = "",
-                            isAddCategory = false
-                        )
-                    }
-                }
+                _uiEvent.emit(UIEvent.SuccessShowToast("수입 카테고리를 저장했습니다!"))
 
-                DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
+                load()
             }
+
+            is DataResourceResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = result.exception,
+                        category = "",
+                        isAddCategory = false
+                    )
+                }
+            }
+
+            DataResourceResult.DummyConstructor, DataResourceResult.Loading -> {}
         }
+
     }
 
     private suspend fun getExpenseMonthTotalAmount() {
@@ -407,147 +402,67 @@ class TransactionAnalysisViewModel(
     }
 
     private suspend fun getExpenseAllCategoryForMonth() {
-        _uiState.update {
-            it.copy(
-                isLoading = true
+        getExpenseAllCategoryForMonthUseCase(
+            GetExpenseAllCategoryForMonthUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue,
             )
-        }
-
-        combine(
-            getExpenseCategoryListUseCase(),
-            getExpenseMonthAllCategoryUseCase(
-                GetExpenseMonthAllCategoryUseCase.Params(
-                    _uiState.value.currentMonth.year,
-                    _uiState.value.currentMonth.monthValue,
-                )
-            )
-        ) { categoryResult, monthResult ->
-            Pair(categoryResult, monthResult)
-        }.collectLatest { (categoryResult, monthResult) ->
-            when {
-                categoryResult is DataResourceResult.Success && monthResult is DataResourceResult.Success -> {
-                    val allCategories = categoryResult.data.map { CategoryUIModelMapper.mapToLayerModel(it) }
-                    val monthCategory =
-                        monthResult.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
-
-                    val merge = allCategories.map { category ->
-                        val match = monthCategory.find { it.category == category.title }
-                        AllowanceChartCategoryUIModel(
-                            category = category.title,
-                            type = category.type,
-                            amount = match?.amount ?: 0,
-                            percent = match?.percent ?: 0
-                        )
-                    }
-
+        ).collectLatest { result ->
+            when (result) {
+                is DataResourceResult.Success -> {
+                    val chartCategoryUIModels =
+                        result.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
                             uiModel = it.uiModel.copy(
-                                transactionList = merge
+                                transactionList = chartCategoryUIModels
                             )
                         )
                     }
                 }
 
-                categoryResult is DataResourceResult.Failure -> {
+                is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
-                            error = categoryResult.exception
+                            error = result.exception
                         )
                     }
                 }
 
-                monthResult is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = monthResult.exception
-                        )
-                    }
-                }
-
-                else -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false
-                        )
-                    }
-                }
+                else -> {}
             }
         }
     }
 
     private suspend fun getIncomeAllCategoryForMonth() {
-        _uiState.update {
-            it.copy(
-                isLoading = true
+        getIncomeAllCategoryForMonthUseCase(
+            GetIncomeAllCategoryForMonthUseCase.Params(
+                _uiState.value.currentMonth.year,
+                _uiState.value.currentMonth.monthValue,
             )
-        }
-
-        combine(
-            getIncomeCategoryListUseCase(),
-            getIncomeMonthAllCategoryUseCase(
-                GetIncomeMonthAllCategoryUseCase.Params(
-                    _uiState.value.currentMonth.year,
-                    _uiState.value.currentMonth.monthValue,
-                )
-            )
-        ) { categoryResult, monthResult ->
-            Pair(categoryResult, monthResult)
-        }.collectLatest { (categoryResult, monthResult) ->
-            when {
-                categoryResult is DataResourceResult.Success && monthResult is DataResourceResult.Success -> {
-                    val allCategories = categoryResult.data.map { CategoryUIModelMapper.mapToLayerModel(it) }
-                    val monthCategory =
-                        monthResult.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
-
-                    val merge = allCategories.map { category ->
-                        val match = monthCategory.find { it.category == category.title }
-                        AllowanceChartCategoryUIModel(
-                            category = category.title,
-                            type = category.type,
-                            amount = match?.amount ?: 0,
-                            percent = match?.percent ?: 0
-                        )
-                    }
-
+        ).collectLatest { result ->
+            when (result) {
+                is DataResourceResult.Success -> {
+                    val chartCategoryUIModels =
+                        result.data.map { AllowanceChartCategoryUIModelMapper.mapToLayerModel(it) }
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
                             uiModel = it.uiModel.copy(
-                                transactionList = merge
+                                transactionList = chartCategoryUIModels
                             )
                         )
                     }
                 }
 
-                categoryResult is DataResourceResult.Failure -> {
+                is DataResourceResult.Failure -> {
                     _uiState.update {
                         it.copy(
-                            isLoading = false,
-                            error = categoryResult.exception
+                            error = result.exception
                         )
                     }
                 }
 
-                monthResult is DataResourceResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = monthResult.exception
-                        )
-                    }
-                }
-
-                else -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false
-                        )
-                    }
-                }
+                else -> {}
             }
         }
     }


### PR DESCRIPTION
## 📝작업 내용

> combine을 사용하던 로직을 뷰모델에 두면 책임이 너무 커서 유스케이스를 만들어서 간결하게 만들었습니다.

## 작업 상세 내용

- [x] 비즈니스 로직을 안 담도록 뷰모델을 수정
- [x] 유스케이스에서 else로 처리하면 로딩일 때 토스트가 나와서 분기처리를 추가함. ex) DataResourceResult의 로딩이 전달 되어도 메시지가 전달되지 않도록 함.