### PR TITLE
feat: 퀴즈 클리어 화면 오답노트 풀기 버튼 구현

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/PayKidsApp.kt
@@ -283,13 +283,14 @@ fun PayKidsApp(
                         navController.popBackStack()
                     },
                     onConfirmClick = { clear ->
-                        navController.navigate(QuizNavigationRoute.QuizClearRoute(clear))
+                        navController.navigate(QuizNavigationRoute.QuizClearRoute(stageNumber, clear))
                     }
                 )
             }
 
             composable<QuizNavigationRoute.QuizClearRoute> { backStack ->
                 val targetRoute = backStack.toRoute<QuizNavigationRoute.QuizClearRoute>()
+                val stageNumber = targetRoute.stageNumber
                 val clearType = targetRoute.clear
 
                 QuizClear(
@@ -301,6 +302,9 @@ fun PayKidsApp(
 //                            // 백스택 맨 위에가 홈이라면 기존 화면을 재사용하기 위해서 넣음.
 //                        }
                         navController.popBackStack(TabNavigationRoute.HomeRoute, inclusive = false)
+                    },
+                    onWrongNoteClick = {
+                        navController.navigate(QuizNavigationRoute.QuizRoute(stageNumber, true))
                     }
                 )
             }

--- a/presentation/src/main/java/com/paykidscompose/presentation/navigation/route/QuizNavigationRoute.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/navigation/route/QuizNavigationRoute.kt
@@ -13,7 +13,7 @@ sealed interface QuizNavigationRoute: NavigationRoute {
     data class QuizEntryRoute(val stageNumber: Int, val stageTitle: String): QuizNavigationRoute
 
     @Serializable
-    data class QuizClearRoute(val clear: QuizClearType): QuizNavigationRoute
+    data class QuizClearRoute(val stageNumber: Int, val clear: QuizClearType): QuizNavigationRoute
 
     @Serializable
     data class StudyRoute(val stageNumber: Int): QuizNavigationRoute

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/quiz/clear/QuizClearScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/quiz/clear/QuizClearScreen.kt
@@ -31,18 +31,21 @@ import com.paykidscompose.presentation.ui.theme.White
 @Composable
 fun QuizClear(
     clearType: QuizClearType,
-    onExitClick: () -> Unit = {}
+    onExitClick: () -> Unit = {},
+    onWrongNoteClick: () -> Unit = {}
 ) {
     QuizClearScreen(
         config = clearType.toConfig(),
-        onExitClick = onExitClick
+        onExitClick = onExitClick,
+        onWrongNoteClick = onWrongNoteClick
     )
 }
 
 @Composable
 fun QuizClearScreen(
     config: QuizClearConfigUIModel,
-    onExitClick: () -> Unit = {}
+    onExitClick: () -> Unit = {},
+    onWrongNoteClick: () -> Unit = {}
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         AsyncImage(
@@ -77,7 +80,7 @@ fun QuizClearScreen(
                 Spacer(modifier = Modifier.height(QuizClearButtonSpacer))
                 DecisionButton(
                     text = stringResource(R.string.text_btn_review),
-                    onClick = {},
+                    onClick = onWrongNoteClick,
                     backgroundColor = Blue2,
                     textStyle = QuizClearButtonTextStyle.copy(color = White)
                 )


### PR DESCRIPTION
## 📝작업 내용

> 퀴즈 클리어 화면 오답노트 풀기 버튼 구현

## 작업 상세 내용

- [x] QuizClearRoute stageNumber 파라미터 추가
- [x] PayKidsApp에서 stageNumber를 전달해 오답노트 풀기 구현
- [x] QuizClear에서 onWrongNoteClick 전달

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

>