### PR TITLE
fix: 홈 화면 스테이지 클릭 시 발생하는 스테이지 정보 갱신 오류 해결

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/home/HomeScreen.kt
@@ -98,7 +98,7 @@ fun Home(
 
     val tooltipOffset = remember { mutableStateOf<Offset?>(null) }
 
-    SideEffect {
+    LaunchedEffect(Unit) {
         homeViewModel.loadAllData()
     }
 


### PR DESCRIPTION
## 📝작업 내용

>  홈 화면에서 스테이지를 클릭 시 스테이지 정보가 항상 마지막으로 해금된 스테이지로 갱신되는 문제 해결
## 작업 상세 내용

- [x] SideEffect -> LaunchedEffect로 재수정

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> LaunchedEffect로 다시 바꾸니까 됩니다. SideEffect를 사용하면 스테이지 클릭할 때마다 적용되는 것 같습니다.
