### PR TITLE
refactor: 학습하기 화면 GPT 응답 대기 애니메이션 처리

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/mapper/study/ChatMessageUIModelMapper.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/mapper/study/ChatMessageUIModelMapper.kt
@@ -11,6 +11,7 @@ object ChatMessageUIModelMapper: ModelMapper<ChatResponseModel, ChatMessageUIMod
 
     override fun mapToLayerModel(model: ChatResponseModel): ChatMessageUIModel {
         return ChatMessageUIModel(
+            id = "",
             text = model.response,
             isFromGpt = true
         )

--- a/presentation/src/main/java/com/paykidscompose/presentation/model/study/ChatMessageUIModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/model/study/ChatMessageUIModel.kt
@@ -3,6 +3,7 @@ package com.paykidscompose.presentation.model.study
 import com.paykidscompose.presentation.model.UIModel
 
 data class ChatMessageUIModel(
+    val id: String,
     val text: String,
     val isFromGpt: Boolean
 ): UIModel()

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/study/StudyScreen.kt
@@ -1,6 +1,11 @@
 package com.paykidscompose.presentation.screen.study
 
 import android.widget.Toast
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -8,6 +13,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,6 +34,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -41,7 +48,6 @@ import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.model.study.ChatMessageUIModel
 import com.paykidscompose.presentation.screen.study.section.StudyTopBar
 import com.paykidscompose.presentation.ui.components.OutlineInputField
-import com.paykidscompose.presentation.ui.components.ScreenLoading
 import com.paykidscompose.presentation.ui.theme.Blue1
 import com.paykidscompose.presentation.ui.theme.Gray1
 import com.paykidscompose.presentation.ui.theme.Gray5
@@ -115,29 +121,23 @@ fun Study(
         }
     }
 
-    when {
-        uiState.isLoading -> {
-            ScreenLoading()
-        }
-        else -> {
-            StudyScreen(
-                modifier = Modifier
-                    .fillMaxSize(),
-                stageNumberText = stageNumberText,
-                userNickname = userNickname,
-                messages = uiState.messages,
-                userInput = uiState.userInput,
-                onBackClick = onBackClick,
-                onUserInputChange = { text -> studyViewModel.onUserInputChange(text) },
-                onSendClick = {
-                    studyViewModel.sendUserInput()
-                },
-                listState = listState
-            )
-        }
-    }
-}
+    StudyScreen(
+        modifier = Modifier
+            .fillMaxSize(),
+        stageNumberText = stageNumberText,
+        userNickname = userNickname,
+        messages = uiState.messages,
+        userInput = uiState.userInput,
+        isLoading = uiState.isLoading,
+        onBackClick = onBackClick,
+        onUserInputChange = { text -> studyViewModel.onUserInputChange(text) },
+        onSendClick = {
+            studyViewModel.sendUserInput()
+        },
+        listState = listState
+    )
 
+}
 
 @Composable
 fun StudyScreen(
@@ -146,11 +146,19 @@ fun StudyScreen(
     userNickname: String,
     messages: List<ChatMessageUIModel>,
     userInput: String,
+    isLoading: Boolean,
     onBackClick: () -> Unit,
     onUserInputChange: (String) -> Unit,
     onSendClick: () -> Unit,
     listState: LazyListState
 ) {
+    // 메시지가 추가될 때 자동으로 맨 아래로 스크롤
+    LaunchedEffect(messages.size) {
+        if (messages.isNotEmpty()) {
+            listState.animateScrollToItem(messages.lastIndex)
+        }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -175,7 +183,7 @@ fun StudyScreen(
 
             items(messages) { message ->
                 if (message.isFromGpt) {
-                    GptBubble(message.text)
+                    GptBubble(message.text, isLoading)
                 } else {
                     UserBubble(userNickname, message.text)
                 }
@@ -212,7 +220,7 @@ fun StageInfoBox(stage: String) {
 }
 
 @Composable
-fun GptBubble(text: String) {
+fun GptBubble(text: String, isLoading: Boolean) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             text = stringResource(R.string.text_chatgpt),
@@ -235,7 +243,11 @@ fun GptBubble(text: String) {
                 )
                 .align(Alignment.Start)
         ) {
-            Text(text, style = StudyChatBubbleTextStyle.copy(color = White))
+            if (isLoading && text.isBlank()) {
+                TypingDots()
+            } else {
+                Text(text, style = StudyChatBubbleTextStyle.copy(color = White))
+            }
         }
     }
 }
@@ -327,11 +339,46 @@ fun ChatInput(
     }
 }
 
+@Composable
+fun TypingDots() {
+    val dotCount = 3
+    val transition = rememberInfiniteTransition()
+
+    val alphaValues = List(dotCount) { index ->
+        transition.animateFloat(
+            initialValue = 0.3f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 500, delayMillis = index * 200),
+                repeatMode = RepeatMode.Reverse
+            )
+        )
+    }
+
+    Row {
+        repeat(dotCount) { index ->
+            Text(
+                text = stringResource(R.string.typing_dot),
+                style = StudyChatBubbleTextStyle.copy(color = White),
+                modifier = Modifier.alpha(alphaValues[index].value)
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 fun GptBubblePreview() {
     PayKidsComposeTheme {
-        GptBubble("안녕하세요")
+        GptBubble("안녕하세요", false)
+    }
+}
+
+@Preview
+@Composable
+fun GptBubbleLoadingPreview() {
+    PayKidsComposeTheme {
+        GptBubble("", true)
     }
 }
 

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/study/StudyViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/study/StudyViewModel.kt
@@ -8,12 +8,14 @@ import com.paykidscompose.common.usecase.study.GetChatResponseUseCase
 import com.paykidscompose.common.usecase.user.GetUserUseCase
 import com.paykidscompose.presentation.base.UIState
 import com.paykidscompose.presentation.mapper.my.MyInfoUIModelMapper
+import com.paykidscompose.presentation.mapper.study.ChatMessageUIModelMapper
 import com.paykidscompose.presentation.model.study.ChatMessageUIModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.UUID
 
 class StudyViewModel(
     private val getChatResponseUseCase: GetChatResponseUseCase,
@@ -35,13 +37,19 @@ class StudyViewModel(
         if (inputText.isBlank()) return
 
         val userMessage = ChatMessageUIModel(
+            id = UUID.randomUUID().toString(),
             text = inputText,
             isFromGpt = false
         )
 
+        val gptMessageId = UUID.randomUUID().toString()
         _uiState.update {
             it.copy(
-                messages = it.messages + userMessage,
+                messages = it.messages + userMessage + ChatMessageUIModel(
+                    id = gptMessageId,
+                    text = "",
+                    isFromGpt = true
+                ), // 타이핑 애니메이션 위해 GPT 버블 미리 생성,
                 userInput = "", // 입력창 비움
                 isLoading = true, error = null
             )
@@ -52,20 +60,27 @@ class StudyViewModel(
                 .collectLatest { result ->
                     when (result) {
                         is DataResourceResult.Success -> {
-                            val gptMessage = ChatMessageUIModel(
-                                text = result.data.response,
-                                isFromGpt = true
-                            )
+                            val uiModel = ChatMessageUIModelMapper.mapToLayerModel(result.data)
                             _uiState.update {
                                 it.copy(
-                                    messages = it.messages + gptMessage,
+                                    messages = it.messages.map { message ->
+                                        if (message.id == gptMessageId) {
+                                            message.copy(text = uiModel.text)
+                                        } else message
+                                    },
                                     isLoading = false
                                 )
                             }
                         }
 
                         is DataResourceResult.Failure -> {
-                            _uiState.update { it.copy(error = result.exception, isLoading = false) }
+                            _uiState.update {
+                                it.copy(
+                                    messages = it.messages.filter { it.id != gptMessageId }, // 타임아웃 등 응답 실패 시 해당 GPT 버블 삭제
+                                    error = result.exception,
+                                    isLoading = false
+                                )
+                            }
                         }
 
                         DataResourceResult.Loading -> {}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@ z   <string name="text_quiz_number">%1$d/%2$d</string>
     <string name="text_study_title">학습하기</string>
     <string name="hint_chat">내용을 입력하세요</string>
     <string name="text_chatgpt">ChatGPT</string>
+    <string name="typing_dot">•</string>
 
     <!-- 마이 페이지 -->
     <string name="content_description_profile">프로필 이미지</string>


### PR DESCRIPTION
## 📝작업 내용

> 학습하기 화면에서 GPT에게 응답 대기하는 동안 말풍선 로딩 애니메이션 추가

## 작업 상세 내용

- [x] ChatMessageUIModel id 속성 추가(UUID 사용)
- [x] 뷰모델에서 타임아웃 등의 응답 실패 시 GPT 메시지 삭제하도록 처리
- [x] 응답 대기 타이핑 애니메이션 구현
- [x] 응답 시 자동 스크롤 구현

### 스크린샷 (선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f4615b91-95fc-45cd-b2e0-c63a24ea61fe" />


### 💬리뷰 요구사항(선택)

>