### PR TITLE
refactor: 스테이지 상태 문자열을 관리하는 enum class 추가

### DIFF
--- a/common/src/main/java/com/paykidscompose/common/enums/StageStatus.kt
+++ b/common/src/main/java/com/paykidscompose/common/enums/StageStatus.kt
@@ -1,0 +1,9 @@
+package com.paykidscompose.common.enums
+
+/** 서버에서 받는 스테이지 상태 문자열 */
+enum class StageStatus(val message: String) {
+    ALL_CLEAR("All Clear"),
+    FIRST("First"),
+    WRONG_ANSWER_NOTE("오답 노트"),
+    REVIEW("복습")
+}

--- a/common/src/main/java/com/paykidscompose/common/usecase/quiz/GetWrongAnswerStatusUseCase.kt
+++ b/common/src/main/java/com/paykidscompose/common/usecase/quiz/GetWrongAnswerStatusUseCase.kt
@@ -1,5 +1,6 @@
 package com.paykidscompose.common.usecase.quiz
 
+import com.paykidscompose.common.enums.StageStatus
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.model.quiz.WrongAnswerNoteStatus
 import com.paykidscompose.common.repository.QuizRepository
@@ -43,10 +44,10 @@ class GetWrongAnswerStatusUseCase @Inject constructor(
                 ?: throw PayKidsException.ToastException(-1, "오답 번호를 불러올 수 없습니다.")
 
             val status = when {
-                checkStage.message == "복습" && wrongNumbers.isEmpty() ->
+                checkStage.message == StageStatus.REVIEW.message && wrongNumbers.isEmpty() ->
                     WrongAnswerNoteStatus.AllCorrect
 
-                checkStage.message == "First" && wrongNumbers.isEmpty() ->
+                checkStage.message == StageStatus.FIRST.message && wrongNumbers.isEmpty() ->
                     WrongAnswerNoteStatus.NoAttempt
 
                 else -> WrongAnswerNoteStatus.HasWrongAnswerNote(wrongNumbers)

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/quiz/QuizViewModel.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/quiz/QuizViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.paykidscompose.common.enums.QuizClearType
+import com.paykidscompose.common.enums.StageStatus
 import com.paykidscompose.common.exception.PayKidsException
 import com.paykidscompose.common.result.DataResourceResult
 import com.paykidscompose.common.usecase.quiz.GetAllQuizzesUseCase
@@ -156,12 +157,12 @@ class QuizViewModel @Inject constructor(
                 is DataResourceResult.Success -> {
                     val clearedModel = QuizClearedUIModelMapper.mapToLayerModel(result.data)
                     val clearType = when {
-                        clearedModel.message == "All Clear" && clearedModel.isCleared -> QuizClearType.ALL_CLEAR
-                        clearedModel.message == "First" && clearedModel.isCleared -> QuizClearType.CLEAR_SUCCESS
-                        clearedModel.message == "First" && !clearedModel.isCleared -> QuizClearType.CLEAR_FAILED
-                        clearedModel.message == "오답 노트" && clearedModel.isCleared -> QuizClearType.WRONG_ANSWER_QUIZ_CLEAR
-                        clearedModel.message == "오답 노트" && !clearedModel.isCleared -> QuizClearType.WRONG_ANSWER_QUIZ_FAILED
-                        clearedModel.message == "복습" && clearedModel.isCleared -> QuizClearType.REVIEW_COMPLETED
+                        clearedModel.message == StageStatus.ALL_CLEAR.message && clearedModel.isCleared -> QuizClearType.ALL_CLEAR
+                        clearedModel.message == StageStatus.FIRST.message && clearedModel.isCleared -> QuizClearType.CLEAR_SUCCESS
+                        clearedModel.message == StageStatus.FIRST.message && !clearedModel.isCleared -> QuizClearType.CLEAR_FAILED
+                        clearedModel.message == StageStatus.WRONG_ANSWER_NOTE.message && clearedModel.isCleared -> QuizClearType.WRONG_ANSWER_QUIZ_CLEAR
+                        clearedModel.message == StageStatus.WRONG_ANSWER_NOTE.message && !clearedModel.isCleared -> QuizClearType.WRONG_ANSWER_QUIZ_FAILED
+                        clearedModel.message == StageStatus.REVIEW.message && clearedModel.isCleared -> QuizClearType.REVIEW_COMPLETED
                         else -> QuizClearType.CLEAR_FAILED
                     }
                     onResult(clearType)


### PR DESCRIPTION
## 📝작업 내용

> 서버에서 받아오는 스테이지 상태 문자열을 enum class로 관리하여 하드코딩 제거

## 작업 상세 내용

- [x] StageStatus enum class 작성
- [x] QuizViewModel 하드코딩 제거
- [x] GetWrongAnswerStatusUseCase 하드코딩 제거

### 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

>