### PR TITLE
refactor: OutLineInputField 컴포넌트 텍스트 중앙 배치 가능하도록 개선

### DIFF
--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/mypage/info/MyInfoScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/mypage/info/MyInfoScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -60,10 +61,8 @@ import com.paykidscompose.presentation.ui.theme.MyInfoScreenBoxSize
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenButtonHorizontalPadding
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenButtonShape
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenButtonVerticalPadding
-import com.paykidscompose.presentation.ui.theme.MyInfoScreenEmailStartPadding
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenMyInfoStartEndPadding
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenMyInfoTopBottomPadding
-import com.paykidscompose.presentation.ui.theme.MyInfoScreenNicknameStartPadding
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenProfileSize
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenShapeBottom
 import com.paykidscompose.presentation.ui.theme.MyInfoScreenShapeTop
@@ -290,7 +289,8 @@ fun NicknameEdit(
             modifier = Modifier
                 .height(OutlineHeight)
                 .weight(1f),
-            startPadding = MyInfoScreenNicknameStartPadding
+            textAlign = TextAlign.Center,
+            contentAlignment = Alignment.Center
         )
 
         Spacer(modifier = Modifier.width(MyInfoScreenSpacer4))
@@ -338,7 +338,8 @@ fun EmailEdit(
             readOnly = true,
             modifier = Modifier.height(OutlineHeight),
             hint = stringResource(R.string.text_email_hint),
-            startPadding = MyInfoScreenEmailStartPadding
+            textAlign = TextAlign.Center,
+            contentAlignment = Alignment.Center
         )
 
     }

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/quiz/section/ShortAnswerQuizContent.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/quiz/section/ShortAnswerQuizContent.kt
@@ -10,8 +10,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.paykidscompose.common.enums.QuizType
 import com.paykidscompose.presentation.R
@@ -26,7 +28,6 @@ import com.paykidscompose.presentation.ui.theme.ShortAnswerImageQuizContentSpace
 import com.paykidscompose.presentation.ui.theme.ShortAnswerQuizContentSpacer
 import com.paykidscompose.presentation.ui.theme.ShortAnswerQuizOutlineHeight
 import com.paykidscompose.presentation.ui.theme.ShortAnswerQuizOutlineShape
-import com.paykidscompose.presentation.ui.theme.ShortAnswerQuizOutlineStartPadding
 import com.paykidscompose.presentation.ui.theme.White
 
 @Composable
@@ -45,7 +46,6 @@ fun ShortAnswerQuizContent(
             if (isSubmitted) isSubmitted = false
             onUserInputChange(it)
         },
-        startPadding = ShortAnswerQuizOutlineStartPadding,
         modifier = Modifier
             .height(ShortAnswerQuizOutlineHeight),
         backgroundColor = White,
@@ -53,6 +53,8 @@ fun ShortAnswerQuizContent(
         hint = stringResource(R.string.hint_input_answer),
         hintColor = Gray2,
         style = QuizShortAnswerTextStyle,
+        textAlign = TextAlign.Center,
+        contentAlignment = Alignment.Center,
         shape = RoundedCornerShape(ShortAnswerQuizOutlineShape),
         enabled = !isSubmitted,
         shadowElevation = CardShadowElevation,

--- a/presentation/src/main/java/com/paykidscompose/presentation/screen/study/StudyScreen.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/screen/study/StudyScreen.kt
@@ -392,6 +392,14 @@ fun UserBubblePreview() {
 
 @Preview
 @Composable
+fun ChatInputPreview() {
+    PayKidsComposeTheme {
+        ChatInput("", {}) { }
+    }
+}
+
+@Preview
+@Composable
 fun StudyScreenPreview() {
     PayKidsComposeTheme {
         Study(stageNumber = 3)

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/components/TextComponents.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/components/TextComponents.kt
@@ -18,11 +18,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.paykidscompose.presentation.R
 import com.paykidscompose.presentation.ui.theme.Black
+import com.paykidscompose.presentation.ui.theme.CardShadowElevation
 import com.paykidscompose.presentation.ui.theme.FieldAndInfoSpacer
 import com.paykidscompose.presentation.ui.theme.Gray2
 import com.paykidscompose.presentation.ui.theme.Gray6
@@ -34,7 +38,11 @@ import com.paykidscompose.presentation.ui.theme.NicknameScreenFieldBoxHeight
 import com.paykidscompose.presentation.ui.theme.NicknameTitleTextStyle
 import com.paykidscompose.presentation.ui.theme.OutlineBorder
 import com.paykidscompose.presentation.ui.theme.OutlineDefaultShadowElevation
+import com.paykidscompose.presentation.ui.theme.OutlineDefaultTextStartPadding
 import com.paykidscompose.presentation.ui.theme.OutlineShape
+import com.paykidscompose.presentation.ui.theme.QuizShortAnswerTextStyle
+import com.paykidscompose.presentation.ui.theme.ShortAnswerQuizOutlineHeight
+import com.paykidscompose.presentation.ui.theme.ShortAnswerQuizOutlineShape
 import com.paykidscompose.presentation.ui.theme.TitleColor
 import com.paykidscompose.presentation.ui.theme.White
 
@@ -120,8 +128,8 @@ fun UnderlineInputField(
 fun OutlineInputField(
     text: String,
     onTextChange: (String) -> Unit,
-    startPadding: Dp,
     modifier: Modifier = Modifier,
+    startPadding: Dp = OutlineDefaultTextStartPadding,
     readOnly: Boolean = false,
     outlineColor: Color = Gray6,
     backgroundColor: Color = Color.Unspecified,
@@ -129,6 +137,8 @@ fun OutlineInputField(
     hintColor: Color = Gray7,
     textColor: Color = Black,
     style: TextStyle = MyInfoCardNicknameTextStyle.copy(color = Black),
+    textAlign: TextAlign = TextAlign.Start,
+    contentAlignment: Alignment = Alignment.CenterStart,
     shape: Shape = RoundedCornerShape(OutlineShape),
     singleLine: Boolean = true,
     enabled: Boolean = true,
@@ -140,18 +150,27 @@ fun OutlineInputField(
         onValueChange = onTextChange,
         modifier = Modifier
             .fillMaxWidth()
-            .shadow(elevation = shadowElevation, shape = shape, ambientColor = shadowColor, spotColor = shadowColor)
+            .shadow(
+                elevation = shadowElevation,
+                shape = shape,
+                ambientColor = shadowColor,
+                spotColor = shadowColor
+            )
             .clip(shape)
             .background(color = backgroundColor)
             .border(OutlineBorder, outlineColor, shape)
-            .padding(start = startPadding).then(modifier),
-        textStyle = style.copy(color = textColor),
+            .padding(start = startPadding)
+            .then(modifier),
+        textStyle = style.copy(
+            color = textColor,
+            textAlign = textAlign
+        ),
         singleLine = singleLine,
         readOnly = readOnly,
         enabled = enabled,
         decorationBox = { innerTextField ->
             Box(
-                contentAlignment = Alignment.CenterStart,
+                contentAlignment = contentAlignment,
                 modifier = Modifier
                     .fillMaxWidth()
             ) {
@@ -167,4 +186,21 @@ fun OutlineInputField(
 @Preview(showBackground = true)
 @Composable
 fun TextPreview() {
+    OutlineInputField(
+        text = "user Input",
+        onTextChange = {
+
+        },
+        startPadding = 0.dp,
+        modifier = Modifier
+            .height(ShortAnswerQuizOutlineHeight),
+        backgroundColor = White,
+        outlineColor = Gray2,
+        hint = stringResource(R.string.hint_input_answer),
+        hintColor = Gray2,
+        style = QuizShortAnswerTextStyle,
+        shape = RoundedCornerShape(ShortAnswerQuizOutlineShape),
+        shadowElevation = CardShadowElevation,
+        shadowColor = Gray2
+    )
 }

--- a/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
+++ b/presentation/src/main/java/com/paykidscompose/presentation/ui/theme/Dimens.kt
@@ -218,8 +218,8 @@ val OutlineShape = 10.dp
 val OutlineHeight = 40.dp
 val OutlineDefaultShadowElevation = 0.dp
 val ShortAnswerQuizOutlineHeight = 86.dp
-val ShortAnswerQuizOutlineStartPadding = 91.dp
 val ShortAnswerQuizOutlineShape = 20.dp
+val OutlineDefaultTextStartPadding = 0.dp
 
 // 팝업 다이얼로그
 val PopupDialogCardShape = 20.dp


### PR DESCRIPTION
## 📝작업 내용

> OutLineInputField 컴포넌트 텍스트 중앙 배치 가능하도록 개선

## 작업 상세 내용

- [x] OutLineInputField 컴포넌트에 TextAlignment, Alignment 활용해 텍스트 중앙 배치 가능하도록 수정
- [x] MyInfoScreen 닉네임, 이메일 수정 텍스트 중앙 정렬
- [x] 주관식 퀴즈 텍스트 입력 중앙 정렬

### 스크린샷 (선택)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/da7f6ca9-d561-4a68-9761-ad18b6d5d982" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/81524b17-a247-49f5-b2ae-7a0ef4d2edec" />

### 💬리뷰 요구사항(선택)

> 기본값으로는 기존처럼 텍스트가 왼쪽 정렬되도록 구현해 중앙 정렬해야 하는 화면만 수정했습니다.(다른 화면은 영향 받지 않습니다.)
